### PR TITLE
Feat/#10 컬렉션 생성 API 구현

### DIFF
--- a/apps/api/src/main/java/kr/flint/api/FlintApiApplication.java
+++ b/apps/api/src/main/java/kr/flint/api/FlintApiApplication.java
@@ -2,8 +2,12 @@ package kr.flint.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = "kr.flint")
+@EnableJpaRepositories(basePackages = "kr.flint")
+@EntityScan(basePackages = "kr.flint")
 public class FlintApiApplication {
 
     public static void main(String[] args) {

--- a/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
@@ -1,0 +1,30 @@
+package kr.flint.api.collection.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.flint.api.collection.service.CollectionCommandFacade;
+import kr.flint.collection.dto.request.CreateCollectionReq;
+import kr.flint.shared.dto.response.SuccessCode;
+import kr.flint.shared.dto.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/collections")
+public class CollectionController {
+	private final CollectionCommandFacade collectionCommandFacade;
+
+	@PostMapping
+	public ResponseEntity<SuccessResponse<?>> postCollection(
+		//@AuthenticationPrincipal Long userId,
+		@RequestBody CreateCollectionReq createCollectionReq
+	){
+		collectionCommandFacade.createCollection(1L, createCollectionReq);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+}

--- a/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import kr.flint.api.collection.service.CollectionCommandFacade;
 import kr.flint.collection.dto.request.CreateCollectionReq;
 import kr.flint.shared.dto.response.SuccessCode;
@@ -22,9 +23,11 @@ public class CollectionController {
 	@PostMapping
 	public ResponseEntity<SuccessResponse<?>> postCollection(
 		//@AuthenticationPrincipal Long userId,
-		@RequestBody CreateCollectionReq createCollectionReq
+		@Valid @RequestBody CreateCollectionReq createCollectionReq
 	){
 		collectionCommandFacade.createCollection(1L, createCollectionReq);
-		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+		return ResponseEntity
+			.status(SuccessCode.SUCCESS_CREATE.getHttpStatus())
+			.body(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
 	}
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionCommandFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionCommandFacade.java
@@ -1,0 +1,25 @@
+package kr.flint.api.collection.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.flint.collection.dto.request.CreateCollectionReq;
+import kr.flint.collection.service.CollectionService;
+import kr.flint.user.domain.User;
+import kr.flint.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CollectionCommandFacade {
+	private final CollectionService collectionService;
+	private final UserService userService;
+
+	@Transactional
+	public void createCollection(final Long userId, final CreateCollectionReq createCollectionReq) {
+		userService.getById(userId);
+		collectionService.createCollection(userId, createCollectionReq);
+	}
+}

--- a/apps/api/src/main/java/kr/flint/api/config/SecurityConfig.java
+++ b/apps/api/src/main/java/kr/flint/api/config/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/auth/**",
             "/actuator/health",
-            "/actuator/info"
+            "/actuator/info",
+            "/api/v1/**",
     };
 
     @Bean

--- a/apps/api/src/main/resources/application-local.yml
+++ b/apps/api/src/main/resources/application-local.yml
@@ -7,15 +7,15 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
 
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-      password: ${REDIS_PASSWORD}
-      database: ${REDIS_DATABASE}
+      password: ${REDIS_PASSWORD:}
+      database: ${REDIS_DATABASE:0}
 
 decorator:
   datasource:

--- a/modules/collection/src/main/java/kr/flint/collection/dto/request/CreateCollectionReq.java
+++ b/modules/collection/src/main/java/kr/flint/collection/dto/request/CreateCollectionReq.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 
 public record CreateCollectionReq(
 	@NotNull(message = "컬렉션 이미지는 필수 입력값입니다")
-	String url,
+	String imageUrl,
 	@NotNull(message = "컬렉션 제목은 필수 입력 값입니다")
 	@Size(min = 0, max = 20)
 	String title,
@@ -16,6 +16,6 @@ public record CreateCollectionReq(
 	@NotNull(message = "공개여부는 필수 입력값입니다")
 	boolean isPublic,
 	@NotNull(message = "작품은 필수 입력값입니다")
-	List<Long> contentIdList
+	List<AddContentReq> contentList
 ) {
 }

--- a/modules/collection/src/main/java/kr/flint/collection/repository/CollectionContentRepository.java
+++ b/modules/collection/src/main/java/kr/flint/collection/repository/CollectionContentRepository.java
@@ -1,0 +1,10 @@
+package kr.flint.collection.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.flint.collection.domain.CollectionContent;
+
+@Repository
+public interface CollectionContentRepository extends JpaRepository<CollectionContent, Long> {
+}

--- a/modules/collection/src/main/java/kr/flint/collection/repository/CollectionRepository.java
+++ b/modules/collection/src/main/java/kr/flint/collection/repository/CollectionRepository.java
@@ -1,0 +1,10 @@
+package kr.flint.collection.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.flint.collection.domain.Collection;
+
+@Repository
+public interface CollectionRepository extends CrudRepository<Collection, Long> {
+}

--- a/modules/collection/src/main/java/kr/flint/collection/repository/CollectionRepository.java
+++ b/modules/collection/src/main/java/kr/flint/collection/repository/CollectionRepository.java
@@ -1,10 +1,10 @@
 package kr.flint.collection.repository;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import kr.flint.collection.domain.Collection;
 
 @Repository
-public interface CollectionRepository extends CrudRepository<Collection, Long> {
+public interface CollectionRepository extends JpaRepository<Collection, Long> {
 }

--- a/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
+++ b/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
@@ -1,0 +1,48 @@
+package kr.flint.collection.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.flint.collection.domain.Collection;
+import kr.flint.collection.domain.CollectionContent;
+import kr.flint.collection.dto.request.CreateCollectionReq;
+import kr.flint.collection.repository.CollectionContentRepository;
+import kr.flint.collection.repository.CollectionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollectionService {
+	private final CollectionRepository collectionRepository;
+	private final CollectionContentRepository collectionContentRepository;
+
+	@Transactional
+	public void createCollection(final Long userId, final CreateCollectionReq createCollectionReq) {
+		//Collection 생성
+		Collection newCollection = Collection.create(
+			createCollectionReq.title(),
+			createCollectionReq.description(),
+			createCollectionReq.imageUrl(),
+			createCollectionReq.isPublic(),
+			userId
+		);
+
+		//Collection 저장
+		Collection savedCollection = collectionRepository.save(newCollection);
+
+		//CollectionContent 중간매핑 엔티티 저장
+		List<CollectionContent> collectionContentList = createCollectionReq.contentList().stream()
+			.map(req -> CollectionContent.create(
+				savedCollection,
+				req.contentId(),
+				req.isSpoiler(),
+				req.reason()
+			))
+			.toList();
+
+		collectionContentRepository.saveAll(collectionContentList);
+	}
+}

--- a/modules/shared/src/main/java/kr/flint/shared/dto/response/SuccessCode.java
+++ b/modules/shared/src/main/java/kr/flint/shared/dto/response/SuccessCode.java
@@ -1,0 +1,20 @@
+package kr.flint.shared.dto.response;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {    /* 201 CREATED */
+	SUCCESS_CREATE(HttpStatus.CREATED, "생성이 완료되었습니다"),
+
+	/* 200 OK */
+	SUCCESS_UPDATE(HttpStatus.OK, "업데이트가 완료되었습니다"),
+	SUCCESS_DELETE(HttpStatus.OK, "삭제가 완료되었습니다"),
+	SUCCESS_FETCH(HttpStatus.OK, "요청 데이터가 성공적으로 조회되었습니다");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/modules/shared/src/main/java/kr/flint/shared/dto/response/SuccessCode.java
+++ b/modules/shared/src/main/java/kr/flint/shared/dto/response/SuccessCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum SuccessCode {    /* 201 CREATED */
+public enum SuccessCode {
+	/* 201 CREATED */
 	SUCCESS_CREATE(HttpStatus.CREATED, "생성이 완료되었습니다"),
 
 	/* 200 OK */

--- a/modules/shared/src/main/java/kr/flint/shared/dto/response/SuccessResponse.java
+++ b/modules/shared/src/main/java/kr/flint/shared/dto/response/SuccessResponse.java
@@ -1,0 +1,22 @@
+package kr.flint.shared.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"status", "message", "data"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SuccessResponse<T>(
+	int status,
+	String message,
+	T data
+) {
+	//성공응답(데이터 없음)
+	public static <T> SuccessResponse<T> of(SuccessCode successCode) {
+		return new SuccessResponse<>(successCode.getHttpStatus().value(), successCode.getMessage(), null);
+	}
+
+	//성공응답(데이터 있음)
+	public static <T> SuccessResponse<T> of(SuccessCode successCode, T data) {
+		return new SuccessResponse<>(successCode.getHttpStatus().value(), successCode.getMessage(), data);
+	}
+}

--- a/modules/user/src/main/java/kr/flint/user/repository/UserRepository.java
+++ b/modules/user/src/main/java/kr/flint/user/repository/UserRepository.java
@@ -2,9 +2,11 @@ package kr.flint.user.repository;
 
 import kr.flint.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByNickname(String nickname);


### PR DESCRIPTION
## 📣 Related Issue

- close #10 

## 📝 Summary

- [ ] 컬렉션 생성 API 구현
- [ ] 누락된 설정 추가

## 🙏 Question & PR point

- 현재 user 생성 로직이 없어 `userId 1`로 하드코딩하여 임의 user를 만들어 구현하였습니다. 추후 user 생성 로직이 생기면 해당 부분 변경하겠습니다

## 📬 Postman

### ✅Success
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/810802c9-589b-4801-862a-d5cdd63116aa" />

### 성공 후 DB 상태

- **collection_content**
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/115d0b9f-80e4-4f54-9566-7a7f22740aa8" />

- **collection**
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/e18c6d3e-2774-4ae2-ba2f-4dcf4d001a94" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 컬렉션 생성을 위한 새로운 API 엔드포인트 추가
  * 표준화된 API 성공 응답 형식 구현

* **설정 변경**
  * 공개 API 엔드포인트 범위 확대
  * JPA 저장소 및 엔티티 스캔 구성 추가
  * 로컬 환경 설정 업데이트 (JPA DDL 및 Redis 기본값)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->