### PR TITLE
[Feat/#14] 컬렉션 탐색/상세조회/리스트 조회 API 구현

### DIFF
--- a/apps/api/src/main/java/kr/flint/api/bookmark/repository/BookmarkQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/bookmark/repository/BookmarkQueryRepository.java
@@ -1,0 +1,11 @@
+package kr.flint.api.bookmark.repository;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkQueryRepository {
+
+}

--- a/apps/api/src/main/java/kr/flint/api/bookmark/service/BookmarkCommandFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/bookmark/service/BookmarkCommandFacade.java
@@ -24,7 +24,7 @@ public class BookmarkCommandFacade {
 		boolean isBookmarked = bookmarkService.toggleContent(userId, contentId);
 
 		if (isBookmarked) {contentService.increaseBookmarkCount(contentId);}
-		else {collectionService.decreaseBookmarkCount(contentId);}
+		else {contentService.decreaseBookmarkCount(contentId);}
 
 		return isBookmarked;
 	}

--- a/apps/api/src/main/java/kr/flint/api/bookmark/service/BookmarkCommandFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/bookmark/service/BookmarkCommandFacade.java
@@ -1,29 +1,43 @@
 package kr.flint.api.bookmark.service;
 
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.flint.bookmark.service.BookmarkService;
+import kr.flint.collection.service.CollectionService;
+import kr.flint.content.service.ContentService;
 import kr.flint.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
-@Service
+@Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class BookmarkCommandFacade {
 	private final BookmarkService bookmarkService;
+	private final ContentService contentService;
+	private final CollectionService collectionService;
 	private final UserService userService;
 
 	@Transactional
 	public boolean toggleContent(final Long userId, final Long contentId) {
 		userService.getById(userId);
-		return bookmarkService.toggleContent(userId, contentId);
+		boolean isBookmarked = bookmarkService.toggleContent(userId, contentId);
+
+		if (isBookmarked) {contentService.increaseBookmarkCount(contentId);}
+		else {collectionService.decreaseBookmarkCount(contentId);}
+
+		return isBookmarked;
 	}
 
 	@Transactional
 	public boolean toggleCollection(final Long userId, final Long collectionId) {
 		userService.getById(userId);
-		return bookmarkService.toggleCollection(userId, collectionId);
+		boolean isBookmarked = bookmarkService.toggleCollection(userId, collectionId);
+
+		if (isBookmarked) {collectionService.increaseBookmarkCount(collectionId);}
+		else {collectionService.decreaseBookmarkCount(collectionId);}
+
+		return isBookmarked;
 	}
 
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
@@ -1,15 +1,19 @@
 package kr.flint.api.collection.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import kr.flint.api.collection.service.CollectionCommandFacade;
+import kr.flint.api.collection.service.CollectionQueryFacade;
 import kr.flint.collection.dto.request.CreateCollectionReq;
+import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import kr.flint.shared.dto.PaginationResponse;
 import kr.flint.shared.dto.response.SuccessCode;
 import kr.flint.shared.dto.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/collections")
 public class CollectionController {
 	private final CollectionCommandFacade collectionCommandFacade;
+	private final CollectionQueryFacade collectionQueryFacade;
 
 	@PostMapping
 	public ResponseEntity<SuccessResponse<?>> postCollection(
@@ -29,5 +34,14 @@ public class CollectionController {
 		return ResponseEntity
 			.status(SuccessCode.SUCCESS_CREATE.getHttpStatus())
 			.body(SuccessResponse.of(SuccessCode.SUCCESS_CREATE));
+	}
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse<PaginationResponse<GetCollectionSimpleRes>>> getCollection(
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		PaginationResponse<GetCollectionSimpleRes> collectionList = collectionQueryFacade.getCollectionList(cursor, size);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, collectionList));
 	}
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
@@ -1,7 +1,11 @@
 package kr.flint.api.collection.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,10 +13,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import kr.flint.api.collection.dto.response.GetCollectionDetailListRes;
+import kr.flint.api.collection.dto.response.GetCollectionDetailRes;
 import kr.flint.api.collection.service.CollectionCommandFacade;
 import kr.flint.api.collection.service.CollectionQueryFacade;
+import kr.flint.api.collection.service.CollectionQueryService;
 import kr.flint.collection.dto.request.CreateCollectionReq;
 import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import kr.flint.collection.service.CollectionService;
 import kr.flint.shared.dto.PaginationResponse;
 import kr.flint.shared.dto.response.SuccessCode;
 import kr.flint.shared.dto.response.SuccessResponse;
@@ -24,6 +32,8 @@ import lombok.RequiredArgsConstructor;
 public class CollectionController {
 	private final CollectionCommandFacade collectionCommandFacade;
 	private final CollectionQueryFacade collectionQueryFacade;
+	private final CollectionQueryService collectionQueryService;
+	private final CollectionService collectionService;
 
 	@PostMapping
 	public ResponseEntity<SuccessResponse<?>> postCollection(
@@ -37,11 +47,31 @@ public class CollectionController {
 	}
 
 	@GetMapping
-	public ResponseEntity<SuccessResponse<PaginationResponse<GetCollectionSimpleRes>>> getCollection(
+	public ResponseEntity<SuccessResponse<PaginationResponse<GetCollectionSimpleRes>>> discoverCollectionList(
 		@RequestParam(required = false) Long cursor,
 		@RequestParam(defaultValue = "10") int size
 	) {
 		PaginationResponse<GetCollectionSimpleRes> collectionList = collectionQueryFacade.getCollectionList(cursor, size);
 		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, collectionList));
 	}
+
+	@GetMapping("/{collectionId}")
+	public ResponseEntity<SuccessResponse<GetCollectionDetailRes>> getCollectionDetail(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long collectionId
+	){
+		GetCollectionDetailRes collectionDetail = collectionQueryFacade.getCollectionDetail(userId, collectionId);
+		collectionService.saveRecentCollection(userId, collectionId);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, collectionDetail));
+	}
+
+	@GetMapping("/recent")
+	public ResponseEntity<SuccessResponse<List<GetCollectionDetailListRes>>> getRecentCollectionList(
+		@AuthenticationPrincipal Long userId
+	){
+		List<GetCollectionDetailListRes> getCollectionDetailListRes = collectionQueryService.getRecentCollectionList(userId);
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, getCollectionDetailListRes));
+	}
+
+
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/controller/CollectionController.java
@@ -57,19 +57,19 @@ public class CollectionController {
 
 	@GetMapping("/{collectionId}")
 	public ResponseEntity<SuccessResponse<GetCollectionDetailRes>> getCollectionDetail(
-		@AuthenticationPrincipal Long userId,
+		//@AuthenticationPrincipal Long userId,
 		@PathVariable Long collectionId
 	){
-		GetCollectionDetailRes collectionDetail = collectionQueryFacade.getCollectionDetail(userId, collectionId);
-		collectionService.saveRecentCollection(userId, collectionId);
+		GetCollectionDetailRes collectionDetail = collectionQueryFacade.getCollectionDetail(collectionId, 1L);
+		collectionService.saveRecentCollection(1L, collectionId);
 		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, collectionDetail));
 	}
 
 	@GetMapping("/recent")
 	public ResponseEntity<SuccessResponse<List<GetCollectionDetailListRes>>> getRecentCollectionList(
-		@AuthenticationPrincipal Long userId
+		//@AuthenticationPrincipal Long userId
 	){
-		List<GetCollectionDetailListRes> getCollectionDetailListRes = collectionQueryService.getRecentCollectionList(userId);
+		List<GetCollectionDetailListRes> getCollectionDetailListRes = collectionQueryService.getRecentCollectionList(1L);
 		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, getCollectionDetailListRes));
 	}
 

--- a/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailListRes.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailListRes.java
@@ -4,9 +4,9 @@ public record GetCollectionDetailListRes(
 	Long collectionId,
 	String title,
 	String description,
-	int bookmarkCount,
-	boolean isBookmarked,
-
+	String imageUrl,
+	Integer bookmarkCount,
+	Boolean isBookmarked,
 
 	Long userId,
 	String nickname,

--- a/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailListRes.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailListRes.java
@@ -1,0 +1,15 @@
+package kr.flint.api.collection.dto.response;
+
+public record GetCollectionDetailListRes(
+	Long collectionId,
+	String title,
+	String description,
+	int bookmarkCount,
+	boolean isBookmarked,
+
+
+	Long userId,
+	String nickname,
+	String profileUrl
+) {
+}

--- a/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailRes.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailRes.java
@@ -1,0 +1,8 @@
+package kr.flint.api.collection.dto.response;
+
+import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+
+public record GetCollectionDetailRes(
+	GetCollectionSimpleRes getCollectionSimpleRes
+) {
+}

--- a/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailRes.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailRes.java
@@ -26,6 +26,7 @@ public record GetCollectionDetailRes(
 		Long contentId,
 		String title,
 		String thumbnailUrl,
+		String authorName,
 		boolean isBookmarked,
 		int bookmarkCount,
 		boolean isSpoiler,

--- a/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailRes.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/dto/response/GetCollectionDetailRes.java
@@ -1,8 +1,34 @@
 package kr.flint.api.collection.dto.response;
 
-import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import java.time.LocalDate;
+import java.util.List;
 
 public record GetCollectionDetailRes(
-	GetCollectionSimpleRes getCollectionSimpleRes
+	Long collectionId,
+	String title,
+	String description,
+	String imageUrl,
+	LocalDate createdAt,
+	boolean isBookmarked,
+
+	Author author,
+
+	List<Content> contentList
 ) {
+	public record Author(
+		Long userId,
+		String nickname,
+		String profileUrl,
+		String userRole
+	){}
+
+	public record Content(
+		Long contentId,
+		String title,
+		String thumbnailUrl,
+		boolean isBookmarked,
+		int bookmarkCount,
+		boolean isSpoiler,
+		String reason
+	){}
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
@@ -1,6 +1,7 @@
 package kr.flint.api.collection.repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -57,16 +58,12 @@ public class CollectionQueryRepository {
 				collection.title,
 				collection.description,
 				collection.image,
-				Expressions.dateTemplate(
-					LocalDate.class,
-					"DATE({0})",
-					collection.createdAt
-				),
+				collection.createdAt,
 
 				user.id,
 				user.nickname,
 				user.profileImage,
-				user.userRole,
+				user.userRole.stringValue(),
 
 				collectionBookmark.id.isNotNull()
 			))
@@ -86,11 +83,11 @@ public class CollectionQueryRepository {
 				content.title,
 				content.poster,
 
-				collectionContent.isSpoiler,
-				collectionContent.reason,
-
+				contentBookmark.id.isNotNull(),
 				content.bookmarkCount,
-				contentBookmark.id.isNotNull()
+
+				collectionContent.isSpoiler,
+				collectionContent.reason
 			))
 			.from(collectionContent)
 			.join(content).on(content.id.eq(collectionContent.contentId))
@@ -134,7 +131,7 @@ public class CollectionQueryRepository {
 		String title,
 		String description,
 		String imageUrl,
-		LocalDate createdAt,
+		LocalDateTime createdAt,
 
 		Long authorId,
 		String authorName,

--- a/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
@@ -1,0 +1,38 @@
+package kr.flint.api.collection.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import lombok.RequiredArgsConstructor;
+
+import static kr.flint.collection.domain.QCollection.collection;
+
+
+@Repository
+@RequiredArgsConstructor
+public class CollectionQueryRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public List<GetCollectionSimpleRes> getCollectionSimpleList(Long cursor, int size){
+		return jpaQueryFactory
+			.select(Projections.constructor(
+				GetCollectionSimpleRes.class,
+				collection.id,
+				collection.image,
+				collection.title,
+				collection.description
+			))
+			.from(collection)
+			.where(
+				cursor != null ? collection.id.lt(cursor) : null
+			)
+			.orderBy(collection.id.desc())
+			.limit(size + 1L)
+			.fetch();
+	}
+}

--- a/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
@@ -29,7 +29,8 @@ public class CollectionQueryRepository {
 			))
 			.from(collection)
 			.where(
-				cursor != null ? collection.id.lt(cursor) : null
+				cursor != null ? collection.id.lt(cursor) : null,
+				collection.isPublic.isTrue()
 			)
 			.orderBy(collection.id.desc())
 			.limit(size + 1L)

--- a/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
@@ -1,16 +1,26 @@
 package kr.flint.api.collection.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kr.flint.api.collection.dto.response.GetCollectionDetailListRes;
+import kr.flint.api.collection.dto.response.GetCollectionDetailRes;
 import kr.flint.collection.dto.response.GetCollectionSimpleRes;
 import lombok.RequiredArgsConstructor;
 
+import static kr.flint.bookmark.domain.QContentBookmark.*;
 import static kr.flint.collection.domain.QCollection.collection;
+import static kr.flint.collection.domain.QCollectionContent.*;
+import static kr.flint.collection.domain.QRecentViewedCollection.*;
+import static kr.flint.user.domain.QUser.user;
+import static kr.flint.bookmark.domain.QCollectionBookmark.collectionBookmark;
+import static kr.flint.content.domain.QContent.content;
 
 
 @Repository
@@ -25,7 +35,8 @@ public class CollectionQueryRepository {
 				collection.id,
 				collection.image,
 				collection.title,
-				collection.description
+				collection.description,
+				Expressions.nullExpression(LocalDate.class)
 			))
 			.from(collection)
 			.where(
@@ -35,5 +46,105 @@ public class CollectionQueryRepository {
 			.orderBy(collection.id.desc())
 			.limit(size + 1L)
 			.fetch();
+	}
+
+	//Collection 상세조회 중 상단 부분
+	public GetCollectionHeader getHeader(Long collectionId, Long userId){
+		return jpaQueryFactory
+			.select(Projections.constructor(
+				GetCollectionHeader.class,
+				collection.id,
+				collection.title,
+				collection.description,
+				collection.image,
+				Expressions.dateTemplate(
+					LocalDate.class,
+					"DATE({0})",
+					collection.createdAt
+				),
+
+				user.id,
+				user.nickname,
+				user.profileImage,
+				user.userRole,
+
+				collectionBookmark.id.isNotNull()
+			))
+			.from(collection)
+			.join(user).on(user.id.eq(collection.userId))
+			.leftJoin(collectionBookmark).on(collectionBookmark.collectionId.eq(collection.id)
+				.and(collectionBookmark.userId.eq(userId)))
+			.where(collection.id.eq(collectionId))
+			.fetchOne();
+	}
+
+	public List<GetCollectionDetailRes.Content> getContentList(Long collectionId, Long userId){
+		return jpaQueryFactory
+			.select(Projections.constructor(
+				GetCollectionDetailRes.Content.class,
+				content.id,
+				content.title,
+				content.poster,
+
+				collectionContent.isSpoiler,
+				collectionContent.reason,
+
+				content.bookmarkCount,
+				contentBookmark.id.isNotNull()
+			))
+			.from(collectionContent)
+			.join(content).on(content.id.eq(collectionContent.contentId))
+			.leftJoin(contentBookmark).on(
+				contentBookmark.contentId.eq(content.id)
+					.and(contentBookmark.userId.eq(userId))
+			)
+			.where(collectionContent.collection.id.eq(collectionId))
+			.fetch();
+	}
+
+	public List<GetCollectionDetailListRes> getCollectionDetailList(Long userId){
+		return jpaQueryFactory
+			.select(Projections.constructor(
+				GetCollectionDetailListRes.class,
+				collection.id,
+				collection.title,
+				collection.description,
+				collection.image,
+				collection.bookmarkCount,
+
+				collectionBookmark.id.isNotNull(),
+
+				user.id,
+				user.nickname,
+				user.profileImage
+			))
+			.from(recentViewedCollection)
+			.join(collection).on(collection.id.eq(recentViewedCollection.collection.id))
+			.join(user).on(user.id.eq(collection.userId))
+			.leftJoin(collectionBookmark).on(
+				collectionBookmark.collectionId.eq(collection.id)
+					.and(collectionBookmark.userId.eq(userId))
+			)
+			.where(recentViewedCollection.userId.eq(userId))
+			.fetch();
+	}
+
+	public record GetCollectionHeader(
+		Long collectionId,
+		String title,
+		String description,
+		String imageUrl,
+		LocalDate createdAt,
+
+		Long authorId,
+		String authorName,
+		String authorProfileUrl,
+		String userRole,
+
+		boolean isBookmarked
+	){
+		public GetCollectionDetailRes.Author toAuthor(){
+			return new GetCollectionDetailRes.Author(authorId, authorName, authorProfileUrl, userRole);
+		}
 	}
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
@@ -123,6 +123,7 @@ public class CollectionQueryRepository {
 					.and(collectionBookmark.userId.eq(userId))
 			)
 			.where(recentViewedCollection.userId.eq(userId))
+			.orderBy(recentViewedCollection.createdAt.desc())
 			.fetch();
 	}
 

--- a/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/repository/CollectionQueryRepository.java
@@ -82,6 +82,7 @@ public class CollectionQueryRepository {
 				content.id,
 				content.title,
 				content.poster,
+				content.author,
 
 				contentBookmark.id.isNotNull(),
 				content.bookmarkCount,

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionCommandFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionCommandFacade.java
@@ -1,17 +1,14 @@
 package kr.flint.api.collection.service;
 
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.flint.collection.dto.request.CreateCollectionReq;
 import kr.flint.collection.service.CollectionService;
-import kr.flint.user.domain.User;
 import kr.flint.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Service
-@Transactional(readOnly = true)
+@Component
 @RequiredArgsConstructor
 public class CollectionCommandFacade {
 	private final CollectionService collectionService;

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
@@ -34,7 +34,7 @@ public class CollectionQueryFacade {
 			header.title(),
 			header.description(),
 			header.imageUrl(),
-			header.createdAt(),
+			header.createdAt().toLocalDate(),
 			header.isBookmarked(),
 			header.toAuthor(),
 			contentList

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import kr.flint.api.collection.dto.response.GetCollectionDetailRes;
 import kr.flint.api.collection.repository.CollectionQueryRepository;
 import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import kr.flint.collection.exception.CollectionErrorCode;
+import kr.flint.collection.exception.CollectionException;
 import kr.flint.collection.service.CollectionService;
 import kr.flint.shared.dto.PaginationResponse;
 import kr.flint.shared.dto.SliceCursor;
@@ -28,6 +30,10 @@ public class CollectionQueryFacade {
 	public GetCollectionDetailRes getCollectionDetail(final Long collectionId, final Long userId){
 		CollectionQueryRepository.GetCollectionHeader header = collectionQueryRepository.getHeader(collectionId, userId);
 		List<GetCollectionDetailRes.Content> contentList = collectionQueryRepository.getContentList(collectionId, userId);
+
+		if(header == null){
+			throw new CollectionException(CollectionErrorCode.COLLECTION_NOT_FOUND);
+		}
 
 		return new GetCollectionDetailRes(
 			header.collectionId(),

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
@@ -1,0 +1,20 @@
+package kr.flint.api.collection.service;
+
+
+import org.springframework.stereotype.Component;
+
+import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import kr.flint.shared.dto.PaginationResponse;
+import kr.flint.shared.dto.SliceCursor;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CollectionQueryFacade {
+	private final CollectionQueryService collectionQueryService;
+
+	public PaginationResponse<GetCollectionSimpleRes> getCollectionList(Long cursor, int size){
+		SliceCursor<GetCollectionSimpleRes> sliceCursor = collectionQueryService.getCollectionList(cursor, size);
+		return PaginationResponse.ofCursor(sliceCursor);
+	}
+}

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryFacade.java
@@ -1,9 +1,14 @@
 package kr.flint.api.collection.service;
 
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
+import kr.flint.api.collection.dto.response.GetCollectionDetailRes;
+import kr.flint.api.collection.repository.CollectionQueryRepository;
 import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import kr.flint.collection.service.CollectionService;
 import kr.flint.shared.dto.PaginationResponse;
 import kr.flint.shared.dto.SliceCursor;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +17,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CollectionQueryFacade {
 	private final CollectionQueryService collectionQueryService;
+	private final CollectionQueryRepository collectionQueryRepository;
+	private final CollectionService collectionService;
 
 	public PaginationResponse<GetCollectionSimpleRes> getCollectionList(Long cursor, int size){
 		SliceCursor<GetCollectionSimpleRes> sliceCursor = collectionQueryService.getCollectionList(cursor, size);
 		return PaginationResponse.ofCursor(sliceCursor);
+	}
+
+	public GetCollectionDetailRes getCollectionDetail(final Long collectionId, final Long userId){
+		CollectionQueryRepository.GetCollectionHeader header = collectionQueryRepository.getHeader(collectionId, userId);
+		List<GetCollectionDetailRes.Content> contentList = collectionQueryRepository.getContentList(collectionId, userId);
+
+		return new GetCollectionDetailRes(
+			header.collectionId(),
+			header.title(),
+			header.description(),
+			header.imageUrl(),
+			header.createdAt(),
+			header.isBookmarked(),
+			header.toAuthor(),
+			contentList
+		);
 	}
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryService.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.flint.api.collection.dto.response.GetCollectionDetailListRes;
 import kr.flint.api.collection.repository.CollectionQueryRepository;
 import kr.flint.collection.dto.response.GetCollectionSimpleRes;
 import kr.flint.shared.dto.SliceCursor;
@@ -29,5 +30,9 @@ public class CollectionQueryService {
 		String currentCursor = cursor != null ? String.valueOf(cursor) : null;
 
 		return SliceCursor.of(collectionList, currentCursor, nextCursor);
+	}
+
+	public List<GetCollectionDetailListRes> getRecentCollectionList(final Long userId){
+		return collectionQueryRepository.getCollectionDetailList(userId);
 	}
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryService.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryService.java
@@ -33,6 +33,7 @@ public class CollectionQueryService {
 	}
 
 	public List<GetCollectionDetailListRes> getRecentCollectionList(final Long userId){
-		return collectionQueryRepository.getCollectionDetailList(userId);
+		List<GetCollectionDetailListRes> collectionList = collectionQueryRepository.getCollectionDetailList(userId);
+		return collectionList.isEmpty() ? null : collectionList;
 	}
 }

--- a/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryService.java
+++ b/apps/api/src/main/java/kr/flint/api/collection/service/CollectionQueryService.java
@@ -1,0 +1,33 @@
+package kr.flint.api.collection.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.flint.api.collection.repository.CollectionQueryRepository;
+import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import kr.flint.shared.dto.SliceCursor;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollectionQueryService {
+	private final CollectionQueryRepository collectionQueryRepository;
+
+	public SliceCursor<GetCollectionSimpleRes> getCollectionList(final Long cursor, final int size){
+		List<GetCollectionSimpleRes> fetchedCollections = collectionQueryRepository.getCollectionSimpleList(cursor, size);
+
+		boolean hasNext = fetchedCollections.size() > size;
+		List<GetCollectionSimpleRes> collectionList = hasNext ? fetchedCollections.subList(0, size) : fetchedCollections;
+
+		String nextCursor = hasNext
+			? String.valueOf(collectionList.get(collectionList.size() - 1).collectionId())
+			: null;
+
+		String currentCursor = cursor != null ? String.valueOf(cursor) : null;
+
+		return SliceCursor.of(collectionList, currentCursor, nextCursor);
+	}
+}

--- a/apps/api/src/main/java/kr/flint/api/discovery/service/DiscoveryQueryFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/discovery/service/DiscoveryQueryFacade.java
@@ -1,4 +1,4 @@
-package kr.flint.api.discovery;
+package kr.flint.api.discovery.service;
 
 import org.springframework.stereotype.Service;
 

--- a/modules/collection/src/main/java/kr/flint/collection/domain/Collection.java
+++ b/modules/collection/src/main/java/kr/flint/collection/domain/Collection.java
@@ -36,6 +36,9 @@ public class Collection extends BaseTime {
 	@Column(nullable = false)
 	private Long userId;
 
+	@Column(nullable = false)
+	private int bookmarkCount;
+
 	public static Collection create(String title, String description, String image, boolean isPublic, Long userId) {
 		return Collection.builder()
 			.title(title)
@@ -43,7 +46,18 @@ public class Collection extends BaseTime {
 			.image(image)
 			.isPublic(isPublic)
 			.userId(userId)
+			.bookmarkCount(0)
 			.build();
+	}
+
+	public void increaseBookmarkCount() {
+		this.bookmarkCount++;
+	}
+
+	public void decreaseBookmarkCount() {
+		if (this.bookmarkCount > 0) {
+			this.bookmarkCount--;
+		}
 	}
 
 

--- a/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
+++ b/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import kr.flint.shared.domain.BaseTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,6 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "collection_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RecentViewedCollection extends BaseTime {

--- a/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
+++ b/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
@@ -1,5 +1,8 @@
 package kr.flint.collection.domain;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "collection_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@OnDelete(action = OnDeleteAction.CASCADE)
 public class RecentViewedCollection extends BaseTime {
 	@Column(nullable = false)
 	private Long userId;

--- a/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
+++ b/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
@@ -1,5 +1,7 @@
 package kr.flint.collection.domain;
 
+import java.time.LocalDateTime;
+
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -30,8 +32,15 @@ public class RecentViewedCollection extends BaseTime {
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Collection collection;
 
+	@Column(nullable = false)
+	private LocalDateTime viewedAt;
+
 	public static RecentViewedCollection create(Long userId, Collection collection) {
-		return new RecentViewedCollection(userId, collection);
+		return new RecentViewedCollection(userId, collection, LocalDateTime.now());
+	}
+
+	public void updateViewedAt() {
+		this.viewedAt = LocalDateTime.now();
 	}
 
 }

--- a/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
+++ b/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
@@ -1,7 +1,10 @@
-package kr.flint.bookmark.domain;
+package kr.flint.collection.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import kr.flint.shared.domain.BaseTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,11 +19,12 @@ public class RecentViewedCollection extends BaseTime {
 	@Column(nullable = false)
 	private Long userId;
 
-	@Column(nullable = false)
-	private Long collectionId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "collection_id", nullable = false)
+	private Collection collection;
 
-	public static RecentViewedCollection create(Long userId, Long collectionId) {
-		return new RecentViewedCollection(userId, collectionId);
+	public static RecentViewedCollection create(Long userId, Collection collection) {
+		return new RecentViewedCollection(userId, collection);
 	}
 
 }

--- a/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
+++ b/modules/collection/src/main/java/kr/flint/collection/domain/RecentViewedCollection.java
@@ -21,13 +21,13 @@ import lombok.NoArgsConstructor;
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "collection_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@OnDelete(action = OnDeleteAction.CASCADE)
 public class RecentViewedCollection extends BaseTime {
 	@Column(nullable = false)
 	private Long userId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "collection_id", nullable = false)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Collection collection;
 
 	public static RecentViewedCollection create(Long userId, Collection collection) {

--- a/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionRes.java
+++ b/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionRes.java
@@ -1,4 +1,0 @@
-package kr.flint.collection.dto.response;
-
-public record GetCollectionRes() {
-}

--- a/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionSimpleRes.java
+++ b/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionSimpleRes.java
@@ -12,7 +12,7 @@ public record GetCollectionSimpleRes(
 	String imageUrl,
 	String title,
 	String description,
-	LocalDate createdAd
+	LocalDate createdAt
 ) {
 	public static GetCollectionSimpleRes of(Collection collection) {
 		return new GetCollectionSimpleRes(

--- a/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionSimpleRes.java
+++ b/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionSimpleRes.java
@@ -1,0 +1,19 @@
+package kr.flint.collection.dto.response;
+
+import kr.flint.collection.domain.Collection;
+
+public record GetCollectionSimpleRes(
+	Long collectionId,
+	String imageUrl,
+	String title,
+	String description
+) {
+	public static GetCollectionSimpleRes of(Collection collection) {
+		return new GetCollectionSimpleRes(
+			collection.getId(),
+			collection.getImage(),
+			collection.getTitle(),
+			collection.getDescription()
+		);
+	}
+}

--- a/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionSimpleRes.java
+++ b/modules/collection/src/main/java/kr/flint/collection/dto/response/GetCollectionSimpleRes.java
@@ -1,19 +1,36 @@
 package kr.flint.collection.dto.response;
 
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import kr.flint.collection.domain.Collection;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record GetCollectionSimpleRes(
 	Long collectionId,
 	String imageUrl,
 	String title,
-	String description
+	String description,
+	LocalDate createdAd
 ) {
 	public static GetCollectionSimpleRes of(Collection collection) {
 		return new GetCollectionSimpleRes(
 			collection.getId(),
 			collection.getImage(),
 			collection.getTitle(),
-			collection.getDescription()
+			collection.getDescription(),
+			null
+		);
+	}
+
+	public static GetCollectionSimpleRes ofWithCreatedAt(Collection collection) {
+		return new GetCollectionSimpleRes(
+			collection.getId(),
+			collection.getImage(),
+			collection.getTitle(),
+			collection.getDescription(),
+			collection.getCreatedAt().toLocalDate()
 		);
 	}
 }

--- a/modules/collection/src/main/java/kr/flint/collection/repository/CollectionContentRepository.java
+++ b/modules/collection/src/main/java/kr/flint/collection/repository/CollectionContentRepository.java
@@ -1,10 +1,14 @@
 package kr.flint.collection.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import kr.flint.collection.domain.Collection;
 import kr.flint.collection.domain.CollectionContent;
 
 @Repository
 public interface CollectionContentRepository extends JpaRepository<CollectionContent, Long> {
+	List<CollectionContent> findAllByCollection(Collection collection);
 }

--- a/modules/collection/src/main/java/kr/flint/collection/repository/RecentViewedCollectionRepository.java
+++ b/modules/collection/src/main/java/kr/flint/collection/repository/RecentViewedCollectionRepository.java
@@ -1,8 +1,12 @@
 package kr.flint.collection.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import kr.flint.collection.domain.Collection;
 import kr.flint.collection.domain.RecentViewedCollection;
 
 public interface RecentViewedCollectionRepository extends JpaRepository<RecentViewedCollection, Long> {
+	Optional<RecentViewedCollection> findByUserIdAndCollection(Long userId, Collection collection);
 }

--- a/modules/collection/src/main/java/kr/flint/collection/repository/RecentViewedCollectionRepository.java
+++ b/modules/collection/src/main/java/kr/flint/collection/repository/RecentViewedCollectionRepository.java
@@ -1,0 +1,8 @@
+package kr.flint.collection.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.flint.collection.domain.RecentViewedCollection;
+
+public interface RecentViewedCollectionRepository extends JpaRepository<RecentViewedCollection, Long> {
+}

--- a/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
+++ b/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
@@ -77,7 +77,13 @@ public class CollectionService {
 	@Transactional
 	public void saveRecentCollection(final Long userId, final Long collectionId) {
 		Collection collection = getCollectionById(collectionId);
-		RecentViewedCollection recentViewedCollection = RecentViewedCollection.create(userId, collection);
-		recentViewedCollectionRepository.save(recentViewedCollection);
+		recentViewedCollectionRepository
+			.findByUserIdAndCollection(userId, collection)
+			.ifPresentOrElse(
+				RecentViewedCollection::updateViewedAt,
+				() -> recentViewedCollectionRepository.save(
+					RecentViewedCollection.create(userId, collection)
+				)
+			);
 	}
 }

--- a/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
+++ b/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
@@ -7,9 +7,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.flint.collection.domain.Collection;
 import kr.flint.collection.domain.CollectionContent;
+import kr.flint.collection.domain.RecentViewedCollection;
 import kr.flint.collection.dto.request.CreateCollectionReq;
+import kr.flint.collection.dto.response.GetCollectionSimpleRes;
+import kr.flint.collection.exception.CollectionErrorCode;
+import kr.flint.collection.exception.CollectionException;
 import kr.flint.collection.repository.CollectionContentRepository;
 import kr.flint.collection.repository.CollectionRepository;
+import kr.flint.collection.repository.RecentViewedCollectionRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -18,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class CollectionService {
 	private final CollectionRepository collectionRepository;
 	private final CollectionContentRepository collectionContentRepository;
+	private final RecentViewedCollectionRepository recentViewedCollectionRepository;
 
 	@Transactional
 	public void createCollection(final Long userId, final CreateCollectionReq createCollectionReq) {
@@ -44,5 +50,33 @@ public class CollectionService {
 			.toList();
 
 		collectionContentRepository.saveAll(collectionContentList);
+	}
+
+	public GetCollectionSimpleRes getCollectionSimple(final Long collectionId) {
+		Collection collection = getCollectionById(collectionId);
+		return GetCollectionSimpleRes.of(collection);
+	}
+
+	public Collection getCollectionById(final Long collectionId) {
+		return collectionRepository.findById(collectionId)
+			.orElseThrow(() -> new CollectionException(CollectionErrorCode.COLLECTION_NOT_FOUND));
+	}
+
+	@Transactional
+	public void increaseBookmarkCount(final Long collectionId){
+		Collection collection = getCollectionById(collectionId);
+		collection.increaseBookmarkCount();
+	}
+
+	@Transactional
+	public void decreaseBookmarkCount(final Long collectionId){
+		Collection collection = getCollectionById(collectionId);
+	}
+
+	@Transactional
+	public void saveRecentCollection(final Long userId, final Long collectionId) {
+		Collection collection = getCollectionById(collectionId);
+		RecentViewedCollection recentViewedCollection = RecentViewedCollection.create(userId, collection);
+		recentViewedCollectionRepository.save(recentViewedCollection);
 	}
 }

--- a/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
+++ b/modules/collection/src/main/java/kr/flint/collection/service/CollectionService.java
@@ -71,6 +71,7 @@ public class CollectionService {
 	@Transactional
 	public void decreaseBookmarkCount(final Long collectionId){
 		Collection collection = getCollectionById(collectionId);
+		collection.decreaseBookmarkCount();
 	}
 
 	@Transactional

--- a/modules/content/src/main/java/kr/flint/content/domain/Content.java
+++ b/modules/content/src/main/java/kr/flint/content/domain/Content.java
@@ -34,6 +34,9 @@ public class Content extends BaseTime {
 	@Column(nullable = false)
 	private String poster;
 
+	@Column(nullable = false)
+	private int bookmarkCount;
+
 	public static Content create(Long tmdbId, String title, int year, String author, String description, String poster) {
 		return Content.builder()
 			.tmdbId(tmdbId)
@@ -42,6 +45,17 @@ public class Content extends BaseTime {
 			.author(author)
 			.description(description)
 			.poster(poster)
+			.bookmarkCount(0)
 			.build();
+	}
+
+	public void increaseBookmarkCount() {
+		this.bookmarkCount++;
+	}
+
+	public void decreaseBookmarkCount() {
+		if (this.bookmarkCount > 0) {
+			this.bookmarkCount--;
+		}
 	}
 }

--- a/modules/content/src/main/java/kr/flint/content/exception/ContentErrorCode.java
+++ b/modules/content/src/main/java/kr/flint/content/exception/ContentErrorCode.java
@@ -1,0 +1,18 @@
+package kr.flint.content.exception;
+
+import org.springframework.http.HttpStatus;
+
+import kr.flint.shared.exception.AppError;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ContentErrorCode implements AppError {
+	CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTENT.NOT_FOUND", "Content Not Found", "작품을 찾을 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String title;
+	private final String detail;
+}

--- a/modules/content/src/main/java/kr/flint/content/exception/ContentException.java
+++ b/modules/content/src/main/java/kr/flint/content/exception/ContentException.java
@@ -1,0 +1,18 @@
+package kr.flint.content.exception;
+
+import kr.flint.shared.exception.GeneralException;
+
+public class ContentException extends GeneralException {
+
+	public ContentException(ContentErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public ContentException(ContentErrorCode errorCode, Object... args) {
+		super(errorCode, args);
+	}
+
+	public ContentException(ContentErrorCode errorCode, Throwable cause) {
+		super(errorCode, cause);
+	}
+}

--- a/modules/content/src/main/java/kr/flint/content/repository/ContentRepository.java
+++ b/modules/content/src/main/java/kr/flint/content/repository/ContentRepository.java
@@ -1,0 +1,8 @@
+package kr.flint.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.flint.content.domain.Content;
+
+public interface ContentRepository extends JpaRepository<Content, Long> {
+}

--- a/modules/content/src/main/java/kr/flint/content/service/ContentService.java
+++ b/modules/content/src/main/java/kr/flint/content/service/ContentService.java
@@ -1,0 +1,33 @@
+package kr.flint.content.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.flint.content.domain.Content;
+import kr.flint.content.exception.ContentErrorCode;
+import kr.flint.content.exception.ContentException;
+import kr.flint.content.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ContentService {
+	private final ContentRepository contentRepository;
+
+	public Content getContentById(final Long contentId) {
+		return contentRepository.findById(contentId)
+			.orElseThrow(() -> new ContentException(ContentErrorCode.CONTENT_NOT_FOUND));
+	}
+
+	@Transactional
+	public void increaseBookmarkCount(final Long contentId) {
+		Content content = getContentById(contentId);
+		content.increaseBookmarkCount();
+	}
+
+	@Transactional void decreaseBookmarkCount(final Long contentId) {
+		Content content = getContentById(contentId);
+		content.decreaseBookmarkCount();
+	}
+}

--- a/modules/content/src/main/java/kr/flint/content/service/ContentService.java
+++ b/modules/content/src/main/java/kr/flint/content/service/ContentService.java
@@ -26,7 +26,8 @@ public class ContentService {
 		content.increaseBookmarkCount();
 	}
 
-	@Transactional void decreaseBookmarkCount(final Long contentId) {
+	@Transactional
+	public void decreaseBookmarkCount(final Long contentId) {
 		Content content = getContentById(contentId);
 		content.decreaseBookmarkCount();
 	}


### PR DESCRIPTION
## 📣 Related Issue

- close #14 

## 📝 Summary

- [x] 컬렉션 탐색 API 구현
- [x] 컬렉션 상세 조회 API 구현
- [x] 컬렉션 리스트 조회 API 구현

## 🙏 Question & PR point

- 컬렉션 탐색 API를 discovery 계층에 둬야할지, collection 계층에 둬야할지 고민 중에 있습니다. 탐색이라는 역할에 집중을 한다면 discovery 도메인에 두는 게 맞지만 실제로 내부에서 하는 역할을 collection 조회이기에 우선은 collection 도메인 계층에 두었는데 호주님은 어떻게 생각하시는지 궁금합니다!

- `CollectionRepository`와 `CollectionQueryRepository`를 분리하여 전자의 경우 Command 중심과 후자의 경우 API 전용으로 화면중심 설계와 DTO 프로젝션을 통해 QueryDSL을 사용하여 Read만 하도록 책임 분리를 하고자 상속을 받지 않고 나누었습니다.

- 프로젝션을 통해서 필요한 컬럼만 DTO로 뽑아 사용하였습니다

- collection 조회의 경우 북마크 여부/사용자 등등 여러 도메인의 정보가 섞여 facade계층을 따로 두었습니다

## 📬 Postman

### 컬렉션 탐색 API
**다음 데이터가 존재하는 경우**
<img width="1512" height="982" alt="스크린샷 2026-01-09 오후 7 08 45" src="https://github.com/user-attachments/assets/9a240d8a-6a4e-432e-8b97-6905faf497df" />
**다음 데이터가 존재하지 않는 경우**
<img width="1512" height="982" alt="스크린샷 2026-01-09 오후 7 08 36" src="https://github.com/user-attachments/assets/bbf6fe59-f1a4-4581-859e-24adf65fe66f" />

### 컬렉션 상세조회 API
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/ee968f00-8fda-4600-b2ea-4adabd4a38f2" />

### 최근본 컬렉션 리스트 조회 API
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/79cc1843-beb5-451b-a31a-76051f40339f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 컬렉션 목록(커서 페이징), 컬렉션 상세, 최근 본 컬렉션 조회 API 추가
  * 컬렉션 단순/상세 응답 모델 및 상세 목록 응답 모델 추가
  * 최근 본 컬렉션 저장 및 콘텐츠·컬렉션 북마크 카운트 자동 증감 기능 추가

* **리팩토링**
  * 서비스·퍼사드 책임 재구성 및 트랜잭션 경계 조정

* **기타**
  * 신규 엔티티·레포지토리·예외 타입 추가 및 불필요 타입 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->