### PR TITLE
[FEAT] 약관 조회 및 어드민 모듈 init

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,7 +52,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build and Test
-        run: ./gradlew :apps:api:build --parallel --build-cache
+        run: ./gradlew :apps:api:build :apps:admin-api:build --parallel --build-cache
         env:
           DB_URL: jdbc:mysql://localhost:3306/flint_test
           DB_USERNAME: test
@@ -86,13 +86,15 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build bootJar
-        run: ./gradlew :apps:api:bootJar -x test --parallel --build-cache
+        run: ./gradlew :apps:api:bootJar :apps:admin-api:bootJar -x test --parallel --build-cache
 
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v4
         with:
           name: app-jar
-          path: apps/api/build/libs/flint-api-0.0.1-SNAPSHOT.jar
+          path: |
+            apps/api/build/libs/flint-api-0.0.1-SNAPSHOT.jar
+            apps/admin-api/build/libs/flint-admin-api-0.0.1-SNAPSHOT.jar
           retention-days: 1
 
   deploy:

--- a/apps/admin-api/build.gradle
+++ b/apps/admin-api/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'org.springframework.boot'
+}
+
+bootJar {
+    archiveBaseName = 'flint-admin-api'
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.12.1'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    implementation project(':modules:shared')
+    implementation project(':modules:user')
+    implementation project(':modules:auth')
+    implementation project(':modules:terms')
+
+    implementation project(':infra:aws')
+    implementation project(':infra:redis')
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/FlintAdminApiApplication.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/FlintAdminApiApplication.java
@@ -1,0 +1,18 @@
+package kr.flint.admin;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = "kr.flint")
+@ConfigurationPropertiesScan(basePackages = "kr.flint")
+@EnableJpaRepositories(basePackages = "kr.flint")
+@EntityScan(basePackages = "kr.flint")
+public class FlintAdminApiApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(FlintAdminApiApplication.class, args);
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/controller/TermsAdminController.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/controller/TermsAdminController.java
@@ -1,0 +1,36 @@
+package kr.flint.admin.domain.terms.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import kr.flint.admin.domain.terms.controller.spec.TermsAdminControllerDocs;
+import kr.flint.admin.domain.terms.dto.request.TermsCreateReq;
+import kr.flint.admin.domain.terms.service.TermsCommandFacade;
+import kr.flint.admin.global.security.annotation.CurrentUser;
+import kr.flint.shared.dto.response.SuccessCode;
+import kr.flint.shared.dto.response.SuccessResponse;
+import kr.flint.terms.dto.response.TermsRes;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/terms")
+public class TermsAdminController implements TermsAdminControllerDocs {
+
+	private final TermsCommandFacade termsCommandFacade;
+
+	@Override
+	@PostMapping
+	public ResponseEntity<SuccessResponse<TermsRes>> createTerms(
+		@CurrentUser Long adminUserId,
+		@Valid @RequestBody TermsCreateReq request
+	) {
+		return ResponseEntity
+			.status(SuccessCode.SUCCESS_CREATE.getHttpStatus())
+			.body(SuccessResponse.of(SuccessCode.SUCCESS_CREATE, termsCommandFacade.createTerms(adminUserId, request)));
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/controller/spec/TermsAdminControllerDocs.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/controller/spec/TermsAdminControllerDocs.java
@@ -1,0 +1,31 @@
+package kr.flint.admin.domain.terms.controller.spec;
+
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.flint.admin.domain.terms.dto.request.TermsCreateReq;
+import kr.flint.shared.dto.response.SuccessResponse;
+import kr.flint.shared.exception.ProblemDetail;
+import kr.flint.terms.dto.response.TermsRes;
+
+@Tag(name = "Terms Admin", description = "약관 관리 API")
+public interface TermsAdminControllerDocs {
+
+	@Operation(summary = "약관 버전 생성", description = "관리자가 새 약관 버전을 생성합니다.")
+	@SecurityRequirement(name = "bearerAuth")
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "약관 생성 성공", useReturnTypeSchema = true),
+		@ApiResponse(
+			responseCode = "403",
+			description = "관리 권한 없음",
+			content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+		)
+	})
+	ResponseEntity<SuccessResponse<TermsRes>> createTerms(Long adminUserId, TermsCreateReq request);
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/dto/request/TermsCreateReq.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/dto/request/TermsCreateReq.java
@@ -1,0 +1,34 @@
+package kr.flint.admin.domain.terms.dto.request;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import kr.flint.terms.domain.TermsType;
+
+@Schema(description = "약관 생성 요청")
+public record TermsCreateReq(
+	@Schema(description = "약관 유형", example = "SERVICE", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "약관 유형은 필수입니다.")
+	TermsType type,
+
+	@Schema(description = "약관 제목", example = "서비스 이용약관", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "약관 제목은 필수입니다.")
+	@Size(max = 100, message = "약관 제목은 100자 이하여야 합니다.")
+	String title,
+
+	@Schema(description = "약관 본문", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "약관 본문은 필수입니다.")
+	String content,
+
+	@Schema(description = "필수 동의 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "필수 동의 여부는 필수입니다.")
+	Boolean required,
+
+	@Schema(description = "활성 시각", example = "2026-05-01T00:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "활성 시각은 필수입니다.")
+	LocalDateTime activeAt
+) {
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/service/TermsCommandFacade.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/domain/terms/service/TermsCommandFacade.java
@@ -1,0 +1,39 @@
+package kr.flint.admin.domain.terms.service;
+
+import org.springframework.stereotype.Component;
+
+import kr.flint.admin.domain.terms.dto.request.TermsCreateReq;
+import kr.flint.terms.dto.response.TermsRes;
+import kr.flint.terms.exception.TermsErrorCode;
+import kr.flint.terms.exception.TermsException;
+import kr.flint.terms.service.TermsService;
+import kr.flint.user.domain.UserRole;
+import kr.flint.user.dto.response.UserAuthInfo;
+import kr.flint.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TermsCommandFacade {
+
+	private final TermsService termsService;
+	private final UserService userService;
+
+	public TermsRes createTerms(Long adminUserId, TermsCreateReq request) {
+		validateAdmin(adminUserId);
+		return TermsRes.from(termsService.createTermsVersion(
+			request.type(),
+			request.title(),
+			request.content(),
+			request.required(),
+			request.activeAt()
+		));
+	}
+
+	private void validateAdmin(Long userId) {
+		UserAuthInfo authInfo = userService.getAuthInfo(userId);
+		if (!UserRole.ADMIN.name().equals(authInfo.role())) {
+			throw new TermsException(TermsErrorCode.FORBIDDEN_TERMS_ADMIN);
+		}
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminJacksonConfig.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminJacksonConfig.java
@@ -1,0 +1,24 @@
+package kr.flint.admin.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class AdminJacksonConfig {
+
+	@Bean
+	public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+		return builder
+			.serializerByType(Long.class, ToStringSerializer.instance)
+			.serializerByType(Long.TYPE, ToStringSerializer.instance)
+			.modules(new JavaTimeModule())
+			.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.build();
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminSecurityConfig.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminSecurityConfig.java
@@ -1,0 +1,62 @@
+package kr.flint.admin.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import kr.flint.admin.global.security.JwtAuthenticationFilter;
+import kr.flint.admin.global.security.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class AdminSecurityConfig {
+
+	private static final String[] PUBLIC_ENDPOINTS = {
+		"/swagger-ui/**",
+		"/v3/api-docs/**",
+		"/actuator/**"
+	};
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtExceptionFilter jwtExceptionFilter;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+				.anyRequest().authenticated())
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+			.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOriginPatterns(List.of("*"));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminSwaggerConfig.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminSwaggerConfig.java
@@ -1,0 +1,87 @@
+package kr.flint.admin.global.config;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+public class AdminSwaggerConfig {
+
+	@Bean
+	public ModelResolver modelResolver(ObjectMapper objectMapper) {
+		return new ModelResolver(objectMapper);
+	}
+
+	@Bean
+	public OpenApiCustomizer longToStringSchemaCustomizer() {
+		return openApi -> {
+			if (openApi.getComponents() == null || openApi.getComponents().getSchemas() == null) {
+				return;
+			}
+			openApi.getComponents().getSchemas().values().forEach(this::convertLongToString);
+		};
+	}
+
+	@SuppressWarnings("rawtypes")
+	private void convertLongToString(Schema<?> schema) {
+		if (schema == null) {
+			return;
+		}
+
+		Map<String, Schema> properties = schema.getProperties();
+		if (properties != null) {
+			properties.forEach((name, propSchema) -> {
+				if (isLongType(propSchema)) {
+					propSchema.setType("string");
+					propSchema.setFormat(null);
+				}
+				convertLongToString(propSchema);
+			});
+		}
+
+		if (schema.getItems() != null) {
+			convertLongToString(schema.getItems());
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	private boolean isLongType(Schema schema) {
+		return "integer".equals(schema.getType()) && "int64".equals(schema.getFormat());
+	}
+
+	@Bean
+	public OpenAPI openAPI() {
+		SecurityScheme bearerScheme = new SecurityScheme()
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT")
+			.in(SecurityScheme.In.HEADER)
+			.name("Authorization");
+
+		SecurityRequirement securityRequirement = new SecurityRequirement()
+			.addList("bearerAuth");
+
+		return new OpenAPI()
+			.info(new Info()
+				.title("Flint Admin API")
+				.description("Flint Admin API 명세")
+				.version("v1"))
+			.servers(List.of(new Server().url("/").description("Current Server")))
+			.components(new Components().addSecuritySchemes("bearerAuth", bearerScheme))
+			.addSecurityItem(securityRequirement);
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminWebMvcConfig.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/config/AdminWebMvcConfig.java
@@ -1,0 +1,34 @@
+package kr.flint.admin.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import kr.flint.admin.global.security.annotation.CurrentUserResolver;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class AdminWebMvcConfig implements WebMvcConfigurer {
+
+	private static final String API_PREFIX = "/api/v1";
+
+	private final CurrentUserResolver currentUserResolver;
+
+	@Override
+	public void configurePathMatch(PathMatchConfigurer configurer) {
+		configurer.addPathPrefix(API_PREFIX,
+			c -> c.isAnnotationPresent(RestController.class)
+				&& c.getPackageName().startsWith("kr.flint.admin.")
+				&& !c.getPackageName().contains(".config"));
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(currentUserResolver);
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/exception/AdminGlobalExceptionHandler.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/exception/AdminGlobalExceptionHandler.java
@@ -1,0 +1,193 @@
+package kr.flint.admin.global.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import kr.flint.shared.exception.AppError;
+import kr.flint.shared.exception.ErrorCode;
+import kr.flint.shared.exception.GeneralException;
+import kr.flint.shared.exception.ProblemDetail;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class AdminGlobalExceptionHandler {
+
+	@ExceptionHandler(GeneralException.class)
+	public ResponseEntity<ProblemDetail> handleGeneralException(GeneralException e, HttpServletRequest request) {
+		AppError errorCode = e.getErrorCode();
+		log.warn("GeneralException 발생: {} - {}", errorCode.getCode(), e.getMessage());
+
+		ProblemDetail problemDetail = ProblemDetail.from(e, request.getRequestURI());
+
+		return ResponseEntity
+			.status(errorCode.getHttpStatus())
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ProblemDetail> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+		log.warn("입력값 검증 오류: {}", e.getMessage());
+		AppError errorCode = ErrorCode.INVALID_INPUT;
+
+		Map<String, String> errors = new HashMap<>();
+		e.getBindingResult()
+			.getAllErrors()
+			.forEach(error -> {
+				if (error instanceof FieldError fieldError) {
+					errors.put(fieldError.getField(), error.getDefaultMessage());
+				} else {
+					errors.put(error.getObjectName(), error.getDefaultMessage());
+				}
+			});
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			"입력값이 올바르지 않습니다.",
+			request.getRequestURI(),
+			errors
+		);
+
+		return ResponseEntity
+			.badRequest()
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<ProblemDetail> handleMissingParameter(MissingServletRequestParameterException e, HttpServletRequest request) {
+		log.warn("요청 파라미터 누락: {}", e.getParameterName());
+		AppError errorCode = ErrorCode.MISSING_PARAMETER;
+
+		String message = String.format("필수 요청 파라미터 [%s] 누락", e.getParameterName());
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			message,
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.status(errorCode.getHttpStatus())
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ProblemDetail> handleTypeMismatch(MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+		log.warn("파라미터 타입 불일치: {} = {}", e.getName(), e.getValue());
+		AppError errorCode = ErrorCode.INVALID_INPUT;
+
+		String message = String.format("파라미터 [%s]의 값 '%s'이(가) 올바르지 않습니다.", e.getName(), e.getValue());
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			message,
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.badRequest()
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ProblemDetail> handleConstraintViolation(ConstraintViolationException e, HttpServletRequest request) {
+		log.warn("제약 조건 위반: {}", e.getMessage());
+		AppError errorCode = ErrorCode.INVALID_INPUT;
+
+		Map<String, String> errors = new HashMap<>();
+		e.getConstraintViolations().forEach(violation -> {
+			String field = violation.getPropertyPath().toString();
+			if (field.contains(".")) {
+				field = field.substring(field.lastIndexOf(".") + 1);
+			}
+			errors.put(field, violation.getMessage());
+		});
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			"입력값이 올바르지 않습니다.",
+			request.getRequestURI(),
+			errors
+		);
+
+		return ResponseEntity
+			.badRequest()
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(NoResourceFoundException.class)
+	public ResponseEntity<ProblemDetail> handleNoResourceFound(NoResourceFoundException e, HttpServletRequest request) {
+		log.debug("리소스 없음: {}", request.getRequestURI());
+		AppError errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			"요청한 리소스를 찾을 수 없습니다.",
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.status(errorCode.getHttpStatus())
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+	public ResponseEntity<ProblemDetail> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException e, HttpServletRequest request) {
+		log.warn("지원하지 않는 Media-Type: {}", e.getContentType());
+		AppError errorCode = ErrorCode.UNSUPPORTED_MEDIA_TYPE;
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			"지원하지 않는 Media-Type입니다",
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.status(errorCode.getHttpStatus())
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ProblemDetail> handleHttpMessageNotReadable(HttpMessageNotReadableException e, HttpServletRequest request) {
+		log.warn("요청 본문 파싱 오류: {}", e.getMessage());
+		AppError errorCode = ErrorCode.INVALID_INPUT;
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			"요청 본문을 읽을 수 없습니다. JSON 형식 또는 값을 확인해주세요.",
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.badRequest()
+			.body(problemDetail);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ProblemDetail> handleException(Exception e, HttpServletRequest request) {
+		log.error("예상치 못한 오류 발생: {}", e.getMessage(), e);
+		AppError errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+
+		ProblemDetail problemDetail = ProblemDetail.of(
+			errorCode,
+			request.getRequestURI()
+		);
+
+		return ResponseEntity
+			.status(errorCode.getHttpStatus())
+			.body(problemDetail);
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/security/JwtAuthenticationFilter.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,83 @@
+package kr.flint.admin.global.security;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.flint.auth.exception.AuthErrorCode;
+import kr.flint.auth.exception.AuthException;
+import kr.flint.auth.jwt.AccessTokenBlacklist;
+import kr.flint.auth.jwt.JwtProvider;
+import kr.flint.auth.jwt.dto.AccessTokenInfo;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String[] EXCLUDED_PATHS = {
+		"/swagger-ui/**",
+		"/v3/api-docs/**",
+		"/actuator/**"
+	};
+
+	private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+	private final JwtProvider jwtProvider;
+	private final AccessTokenBlacklist accessTokenBlacklist;
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		for (String pattern : EXCLUDED_PATHS) {
+			if (pathMatcher.match(pattern, path)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+		String token = jwtProvider.extractToken(authHeader);
+
+		if (token != null) {
+			if (accessTokenBlacklist.isBlacklisted(token)) {
+				throw new AuthException(AuthErrorCode.TOKEN_BLACKLISTED);
+			}
+
+			AccessTokenInfo claims = jwtProvider.parseAccessToken(token);
+
+			if (claims != null && claims.isValid()) {
+				UserPrincipal principal = new UserPrincipal(claims.userId(), claims.role());
+				List<SimpleGrantedAuthority> authorities = claims.role() != null
+					? List.of(new SimpleGrantedAuthority("ROLE_" + claims.role()))
+					: Collections.emptyList();
+
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/security/JwtExceptionFilter.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/security/JwtExceptionFilter.java
@@ -1,0 +1,51 @@
+package kr.flint.admin.global.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.flint.auth.exception.AuthException;
+import kr.flint.shared.exception.AppError;
+import kr.flint.shared.exception.ProblemDetail;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (AuthException e) {
+			log.warn("JWT 인증 실패: {} - {}", e.getErrorCode(), e.getMessage());
+			setErrorResponse(response, request.getRequestURI(), e.getErrorCode());
+		}
+	}
+
+	private void setErrorResponse(HttpServletResponse response, String requestUri, AppError errorCode) throws IOException {
+		ProblemDetail problemDetail = ProblemDetail.of(errorCode, requestUri);
+
+		response.setStatus(errorCode.getHttpStatus().value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		response.getWriter().write(objectMapper.writeValueAsString(problemDetail));
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/security/UserPrincipal.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/security/UserPrincipal.java
@@ -1,0 +1,14 @@
+package kr.flint.admin.global.security;
+
+import java.security.Principal;
+
+public record UserPrincipal(
+	Long userId,
+	String role
+) implements Principal {
+
+	@Override
+	public String getName() {
+		return String.valueOf(userId);
+	}
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/security/annotation/CurrentUser.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/security/annotation/CurrentUser.java
@@ -1,0 +1,15 @@
+package kr.flint.admin.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Parameter(hidden = true)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+	boolean required() default true;
+}

--- a/apps/admin-api/src/main/java/kr/flint/admin/global/security/annotation/CurrentUserResolver.java
+++ b/apps/admin-api/src/main/java/kr/flint/admin/global/security/annotation/CurrentUserResolver.java
@@ -1,0 +1,53 @@
+package kr.flint.admin.global.security.annotation;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import kr.flint.admin.global.security.UserPrincipal;
+import kr.flint.auth.exception.AuthErrorCode;
+import kr.flint.auth.exception.AuthException;
+
+@Component
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(CurrentUser.class)
+			&& Long.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter parameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		CurrentUser annotation = parameter.getParameterAnnotation(CurrentUser.class);
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+			if (annotation != null && annotation.required()) {
+				throw new AuthException(AuthErrorCode.UNAUTHORIZED);
+			}
+			return null;
+		}
+
+		Object principal = authentication.getPrincipal();
+		if (principal instanceof UserPrincipal userPrincipal) {
+			return userPrincipal.userId();
+		}
+
+		if (annotation != null && annotation.required()) {
+			throw new AuthException(AuthErrorCode.UNAUTHORIZED);
+		}
+		return null;
+	}
+}

--- a/apps/admin-api/src/main/resources/application-dev.yml
+++ b/apps/admin-api/src/main/resources/application-dev.yml
@@ -1,0 +1,38 @@
+spring:
+  config:
+    import:
+      - aws-parameterstore:/config/flint-api/
+      - aws-parameterstore:/config/flint-api/dev/
+
+  datasource:
+    url: ${database.url}
+    username: ${database.username}
+    password: ${database.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true
+      multiline: true
+      logging: slf4j
+
+jwt:
+  secret: ${jwt.secret}
+  access-expiration: 1400000000000000000
+  refresh-expiration: 9000000000000000000
+  temp-expiration: 9000000000000000000
+
+logging:
+  level:
+    kr.flint: debug

--- a/apps/admin-api/src/main/resources/application-local.yml
+++ b/apps/admin-api/src/main/resources/application-local.yml
@@ -1,0 +1,54 @@
+spring:
+  cloud:
+    aws:
+      parameterstore:
+        enabled: false
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD:}
+      database: ${REDIS_DATABASE:0}
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true
+      multiline: true
+      logging: slf4j
+
+p6spy:
+  filter:
+    allow:
+      - kr.flint
+    deny:
+      - kr.flint.shared
+
+cloud:
+  aws:
+    parameterstore:
+      enabled: false
+    secretsmanager:
+      enabled: false
+
+jwt:
+  secret: ${JWT_SECRET:local-dev-secret-key-at-least-32-characters-long}
+  access-expiration: 14d
+  refresh-expiration: 30d
+  temp-expiration: 30m
+
+logging:
+  level:
+    kr.flint: debug

--- a/apps/admin-api/src/main/resources/application-prod.yml
+++ b/apps/admin-api/src/main/resources/application-prod.yml
@@ -1,0 +1,36 @@
+spring:
+  config:
+    import:
+      - aws-parameterstore:/config/flint-api/
+      - aws-parameterstore:/config/flint-api/prod/
+
+  datasource:
+    url: ${database.url}
+    username: ${database.username}
+    password: ${database.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show-sql: false
+
+  data:
+    redis:
+      host: ${redis.host}
+      port: ${redis.port:6379}
+      password: ${redis.password:}
+      database: ${redis.database:0}
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false
+
+jwt:
+  secret: ${jwt.secret}
+  access-expiration: 1h
+  refresh-expiration: 14d
+  temp-expiration: 30m
+
+logging:
+  level:
+    kr.flint: info

--- a/apps/admin-api/src/main/resources/application.yml
+++ b/apps/admin-api/src/main/resources/application.yml
@@ -1,0 +1,52 @@
+spring:
+  application:
+    name: flint-admin-api
+
+  config:
+    import:
+      - optional:file:.env[.properties]
+
+  threads:
+    virtual:
+      enabled: true
+
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        default_batch_fetch_size: 100
+
+  jackson:
+    default-property-inclusion: non_null
+
+server:
+  port: 8081
+  shutdown: graceful
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info
+  endpoint:
+    health:
+      show-details: never
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: false
+      multiline: true
+      logging: slf4j

--- a/apps/admin-api/src/test/java/kr/flint/admin/domain/terms/service/TermsCommandFacadeTest.java
+++ b/apps/admin-api/src/test/java/kr/flint/admin/domain/terms/service/TermsCommandFacadeTest.java
@@ -1,0 +1,88 @@
+package kr.flint.admin.domain.terms.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import kr.flint.admin.domain.terms.dto.request.TermsCreateReq;
+import kr.flint.terms.domain.Terms;
+import kr.flint.terms.domain.TermsType;
+import kr.flint.terms.dto.response.TermsRes;
+import kr.flint.terms.exception.TermsErrorCode;
+import kr.flint.terms.exception.TermsException;
+import kr.flint.terms.service.TermsService;
+import kr.flint.user.dto.response.UserAuthInfo;
+import kr.flint.user.service.UserService;
+
+@ExtendWith(MockitoExtension.class)
+class TermsCommandFacadeTest {
+
+	@Mock
+	private TermsService termsService;
+
+	@Mock
+	private UserService userService;
+
+	@InjectMocks
+	private TermsCommandFacade termsCommandFacade;
+
+	@Nested
+	@DisplayName("createTerms")
+	class CreateTerms {
+
+		@Test
+		@DisplayName("ADMIN은 새 약관 버전을 생성")
+		void adminSuccess() {
+			// given
+			LocalDateTime activeAt = LocalDateTime.now();
+			TermsCreateReq request = new TermsCreateReq(TermsType.SERVICE, "서비스 이용약관", "content", true, activeAt);
+			Terms terms = Terms.create(TermsType.SERVICE, "서비스 이용약관", "content", true, activeAt);
+			ReflectionTestUtils.setField(terms, "id", 1L);
+			when(userService.getAuthInfo(10L)).thenReturn(UserAuthInfo.of(10L, "admin", "ADMIN"));
+			when(termsService.createTermsVersion(TermsType.SERVICE, "서비스 이용약관", "content", true, activeAt))
+				.thenReturn(terms);
+
+			// when
+			TermsRes result = termsCommandFacade.createTerms(10L, request);
+
+			// then
+			assertThat(result.id()).isEqualTo(1L);
+			assertThat(result.type()).isEqualTo(TermsType.SERVICE);
+		}
+
+		@Test
+		@DisplayName("ADMIN이 아니면 약관을 생성할 수 없음")
+		void nonAdminForbidden() {
+			// given
+			LocalDateTime activeAt = LocalDateTime.now();
+			TermsCreateReq request = new TermsCreateReq(TermsType.SERVICE, "서비스 이용약관", "content", true, activeAt);
+			when(userService.getAuthInfo(10L)).thenReturn(UserAuthInfo.of(10L, "user", "FLING"));
+
+			// when & then
+			assertThatThrownBy(() -> termsCommandFacade.createTerms(10L, request))
+				.isInstanceOf(TermsException.class)
+				.extracting("errorCode")
+				.isEqualTo(TermsErrorCode.FORBIDDEN_TERMS_ADMIN);
+			verify(termsService, never()).createTermsVersion(
+				TermsType.SERVICE,
+				"서비스 이용약관",
+				"content",
+				true,
+				activeAt
+			);
+		}
+	}
+}

--- a/apps/api/build.gradle
+++ b/apps/api/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(':modules:taste')
     implementation project(':modules:search')
     implementation project(':modules:ott')
+    implementation project(':modules:terms')
 
     implementation project(':infra:redis')
     implementation project(':infra:storage')

--- a/apps/api/src/main/java/kr/flint/api/domain/auth/controller/spec/AuthControllerDocs.java
+++ b/apps/api/src/main/java/kr/flint/api/domain/auth/controller/spec/AuthControllerDocs.java
@@ -41,7 +41,7 @@ public interface AuthControllerDocs {
 
     @Operation(
             summary = "회원가입 - 호주",
-            description = "임시 토큰과 사용자 정보로 회원가입을 완료합니다."
+            description = "임시 토큰, 사용자 정보, 필수 약관 동의 정보로 회원가입을 완료합니다."
     )
     @ApiResponses({
             @ApiResponse(

--- a/apps/api/src/main/java/kr/flint/api/domain/auth/dto/request/SignupReq.java
+++ b/apps/api/src/main/java/kr/flint/api/domain/auth/dto/request/SignupReq.java
@@ -2,6 +2,8 @@ package kr.flint.api.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -23,6 +25,10 @@ public record SignupReq(
         List<Long> favoriteContentIds,
 
         @Schema(description = "구독 중인 OTT 서비스 ID 목록", example = "[1, 2]")
-        List<Long> subscribedOttIds
+        List<Long> subscribedOttIds,
+
+        @Schema(description = "동의한 약관 ID 목록", example = "[1, 2]", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotEmpty(message = "동의한 약관 ID 목록은 필수입니다.")
+        List<@NotNull(message = "약관 ID는 null일 수 없습니다.") Long> agreedTermsIds
 ) {
 }

--- a/apps/api/src/main/java/kr/flint/api/domain/auth/service/AuthFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/domain/auth/service/AuthFacade.java
@@ -25,6 +25,7 @@ import kr.flint.collection.service.CollectionService;
 import kr.flint.content.service.ContentService;
 import kr.flint.ott.service.OttService;
 import kr.flint.taste.service.TasteService;
+import kr.flint.terms.service.TermsService;
 import kr.flint.user.dto.response.UserAuthInfo;
 import kr.flint.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,7 @@ public class AuthFacade {
 	private final CollectionService collectionService;
 	private final TasteService tasteService;
 	private final ContentService contentService;
+	private final TermsService termsService;
 
 	/**
      * 소셜 로그인
@@ -73,6 +75,7 @@ public class AuthFacade {
 
         UserAuthInfo authInfo = userService.create(request.nickname());
         userIdentityService.create(authInfo.userId(), payload.provider(), payload.providerUserId());
+        termsService.validateAndCreateAgreements(authInfo.userId(), request.agreedTermsIds());
 
         bookmarkCommandService.createContentBookmarks(authInfo.userId(), request.favoriteContentIds());
 		request.favoriteContentIds().forEach(contentService::incContentBookmarkCount);

--- a/apps/api/src/main/java/kr/flint/api/domain/terms/controller/TermsController.java
+++ b/apps/api/src/main/java/kr/flint/api/domain/terms/controller/TermsController.java
@@ -1,0 +1,42 @@
+package kr.flint.api.domain.terms.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.flint.api.domain.terms.controller.spec.TermsControllerDocs;
+import kr.flint.api.domain.terms.service.TermsQueryFacade;
+import kr.flint.shared.dto.response.SuccessCode;
+import kr.flint.shared.dto.response.SuccessResponse;
+import kr.flint.terms.domain.TermsType;
+import kr.flint.terms.dto.response.TermsRes;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/terms")
+public class TermsController implements TermsControllerDocs {
+
+	private final TermsQueryFacade termsQueryFacade;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<SuccessResponse<List<TermsRes>>> getTerms(
+		@RequestParam(required = false) TermsType type
+	) {
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, termsQueryFacade.getTerms(type)));
+	}
+
+	@Override
+	@GetMapping("/{termsId}")
+	public ResponseEntity<SuccessResponse<TermsRes>> getTerms(
+		@PathVariable Long termsId
+	) {
+		return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, termsQueryFacade.getTerms(termsId)));
+	}
+}

--- a/apps/api/src/main/java/kr/flint/api/domain/terms/controller/spec/TermsControllerDocs.java
+++ b/apps/api/src/main/java/kr/flint/api/domain/terms/controller/spec/TermsControllerDocs.java
@@ -1,0 +1,42 @@
+package kr.flint.api.domain.terms.controller.spec;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.flint.shared.dto.response.SuccessResponse;
+import kr.flint.shared.exception.ProblemDetail;
+import kr.flint.terms.domain.TermsType;
+import kr.flint.terms.dto.response.TermsRes;
+
+@Tag(name = "Terms", description = "약관 API")
+public interface TermsControllerDocs {
+
+	@Operation(summary = "약관 목록 조회", description = "현재 활성 약관을 유형별 최신 버전으로 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "약관 목록 조회 성공",
+			content = @Content(array = @ArraySchema(schema = @Schema(implementation = TermsRes.class)))
+		)
+	})
+	ResponseEntity<SuccessResponse<List<TermsRes>>> getTerms(TermsType type);
+
+	@Operation(summary = "약관 상세 조회", description = "약관 ID로 약관 본문을 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "약관 상세 조회 성공", useReturnTypeSchema = true),
+		@ApiResponse(
+			responseCode = "404",
+			description = "약관 없음",
+			content = @Content(schema = @Schema(implementation = ProblemDetail.class))
+		)
+	})
+	ResponseEntity<SuccessResponse<TermsRes>> getTerms(Long termsId);
+}

--- a/apps/api/src/main/java/kr/flint/api/domain/terms/service/TermsQueryFacade.java
+++ b/apps/api/src/main/java/kr/flint/api/domain/terms/service/TermsQueryFacade.java
@@ -1,0 +1,27 @@
+package kr.flint.api.domain.terms.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import kr.flint.terms.domain.TermsType;
+import kr.flint.terms.dto.response.TermsRes;
+import kr.flint.terms.service.TermsService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TermsQueryFacade {
+
+	private final TermsService termsService;
+
+	public List<TermsRes> getTerms(TermsType type) {
+		return termsService.getCurrentTerms(type).stream()
+			.map(TermsRes::from)
+			.toList();
+	}
+
+	public TermsRes getTerms(Long termsId) {
+		return TermsRes.from(termsService.getById(termsId));
+	}
+}

--- a/apps/api/src/test/java/kr/flint/api/ArchitectureTest.java
+++ b/apps/api/src/test/java/kr/flint/api/ArchitectureTest.java
@@ -30,7 +30,8 @@ class ArchitectureTest {
             "kr.flint.collection",
             "kr.flint.bookmark",
             "kr.flint.taste",
-            "kr.flint.search"
+            "kr.flint.search",
+            "kr.flint.terms"
     };
 
     private static final String[] INFRA_MODULES = {

--- a/apps/api/src/test/java/kr/flint/api/domain/auth/service/AuthFacadeTest.java
+++ b/apps/api/src/test/java/kr/flint/api/domain/auth/service/AuthFacadeTest.java
@@ -1,0 +1,133 @@
+package kr.flint.api.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import kr.flint.api.domain.auth.dto.request.SignupReq;
+import kr.flint.api.global.oauth.client.KakaoOAuthClient;
+import kr.flint.auth.dto.AuthTokens;
+import kr.flint.auth.dto.TempTokenPayload;
+import kr.flint.auth.enums.AuthProvider;
+import kr.flint.auth.service.AuthService;
+import kr.flint.auth.service.UserIdentityService;
+import kr.flint.bookmark.service.BookmarkCommandService;
+import kr.flint.collection.service.CollectionService;
+import kr.flint.content.service.ContentService;
+import kr.flint.ott.service.OttService;
+import kr.flint.taste.service.TasteService;
+import kr.flint.terms.exception.TermsErrorCode;
+import kr.flint.terms.exception.TermsException;
+import kr.flint.terms.service.TermsService;
+import kr.flint.user.dto.response.UserAuthInfo;
+import kr.flint.user.service.UserService;
+
+@ExtendWith(MockitoExtension.class)
+class AuthFacadeTest {
+
+	@Mock
+	private AuthService authService;
+
+	@Mock
+	private UserService userService;
+
+	@Mock
+	private UserIdentityService userIdentityService;
+
+	@Mock
+	private KakaoOAuthClient kakaoOAuthClient;
+
+	@Mock
+	private BookmarkCommandService bookmarkCommandService;
+
+	@Mock
+	private OttService ottService;
+
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
+
+	@Mock
+	private CollectionService collectionService;
+
+	@Mock
+	private TasteService tasteService;
+
+	@Mock
+	private ContentService contentService;
+
+	@Mock
+	private TermsService termsService;
+
+	@InjectMocks
+	private AuthFacade authFacade;
+
+	@Nested
+	@DisplayName("signup")
+	class Signup {
+
+		@Test
+		@DisplayName("회원가입 시 약관 동의를 저장")
+		void createTermsAgreements() {
+			// given
+			SignupReq request = new SignupReq(
+				"temp-token",
+				"플린트",
+				List.of(100L),
+				List.of(1L),
+				List.of(10L, 20L)
+			);
+			when(authService.verifyTempToken("temp-token"))
+				.thenReturn(new TempTokenPayload(AuthProvider.KAKAO, "provider-user-id"));
+			when(userService.create("플린트")).thenReturn(UserAuthInfo.of(1L, "플린트", "FLING"));
+			when(authService.issueTokens(1L, "FLING")).thenReturn(AuthTokens.of("access", "refresh", 1L));
+
+			// when
+			var result = authFacade.signup(request);
+
+			// then
+			assertThat(result.accessToken()).isEqualTo("access");
+			verify(termsService).validateAndCreateAgreements(1L, List.of(10L, 20L));
+		}
+
+		@Test
+		@DisplayName("필수 약관 미동의 시 온보딩 후속 처리를 하지 않음")
+		void requiredTermsNotAgreed() {
+			// given
+			SignupReq request = new SignupReq(
+				"temp-token",
+				"플린트",
+				List.of(100L),
+				List.of(1L),
+				List.of(10L)
+			);
+			when(authService.verifyTempToken("temp-token"))
+				.thenReturn(new TempTokenPayload(AuthProvider.KAKAO, "provider-user-id"));
+			when(userService.create("플린트")).thenReturn(UserAuthInfo.of(1L, "플린트", "FLING"));
+			doThrow(new TermsException(TermsErrorCode.REQUIRED_TERMS_NOT_AGREED))
+				.when(termsService).validateAndCreateAgreements(1L, List.of(10L));
+
+			// when & then
+			assertThatThrownBy(() -> authFacade.signup(request))
+				.isInstanceOf(TermsException.class)
+				.extracting("errorCode")
+				.isEqualTo(TermsErrorCode.REQUIRED_TERMS_NOT_AGREED);
+			verify(bookmarkCommandService, never()).createContentBookmarks(1L, List.of(100L));
+			verify(ottService, never()).createUserOtts(1L, List.of(1L));
+			verify(authService, never()).issueTokens(1L, "FLING");
+		}
+	}
+}

--- a/modules/terms/build.gradle
+++ b/modules/terms/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':modules:shared')
+}

--- a/modules/terms/src/main/java/kr/flint/terms/domain/Terms.java
+++ b/modules/terms/src/main/java/kr/flint/terms/domain/Terms.java
@@ -25,7 +25,6 @@ public class Terms extends BaseTime {
 	@Column(nullable = false, length = 100)
 	private String title;
 
-	@Lob
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 

--- a/modules/terms/src/main/java/kr/flint/terms/domain/Terms.java
+++ b/modules/terms/src/main/java/kr/flint/terms/domain/Terms.java
@@ -1,0 +1,64 @@
+package kr.flint.terms.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Lob;
+import kr.flint.shared.domain.BaseTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Terms extends BaseTime {
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 30)
+	private TermsType type;
+
+	@Column(nullable = false, length = 100)
+	private String title;
+
+	@Lob
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column(name = "is_required", nullable = false)
+	private boolean required;
+
+	@Column(nullable = false)
+	private LocalDateTime activeAt;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private Terms(TermsType type, String title, String content, boolean required, LocalDateTime activeAt) {
+		this.type = type;
+		this.title = title;
+		this.content = content;
+		this.required = required;
+		this.activeAt = activeAt;
+	}
+
+	public static Terms create(TermsType type, String title, String content, boolean required, LocalDateTime activeAt) {
+		return Terms.builder()
+			.type(type)
+			.title(title)
+			.content(content)
+			.required(required)
+			.activeAt(activeAt)
+			.build();
+	}
+
+	public boolean isActive(LocalDateTime now) {
+		return !activeAt.isAfter(now);
+	}
+
+	public boolean isNewerThan(Terms other) {
+		return activeAt.isAfter(other.activeAt);
+	}
+}

--- a/modules/terms/src/main/java/kr/flint/terms/domain/TermsType.java
+++ b/modules/terms/src/main/java/kr/flint/terms/domain/TermsType.java
@@ -1,0 +1,15 @@
+package kr.flint.terms.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermsType {
+	SERVICE("서비스 이용약관", true),
+	PRIVACY("개인정보 처리방침", true),
+	MARKETING("마케팅 정보 수신", false);
+
+	private final String description;
+	private final boolean defaultRequired;
+}

--- a/modules/terms/src/main/java/kr/flint/terms/domain/UserTermsAgreement.java
+++ b/modules/terms/src/main/java/kr/flint/terms/domain/UserTermsAgreement.java
@@ -1,0 +1,50 @@
+package kr.flint.terms.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import kr.flint.shared.domain.Base;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+	@UniqueConstraint(name = "uk_user_terms_agreement_user_terms", columnNames = {"user_id", "terms_id"})
+})
+public class UserTermsAgreement extends Base {
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "terms_id", nullable = false)
+	private Long termsId;
+
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime agreedAt;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private UserTermsAgreement(Long userId, Long termsId, LocalDateTime agreedAt) {
+		this.userId = userId;
+		this.termsId = termsId;
+		this.agreedAt = agreedAt;
+	}
+
+	public static UserTermsAgreement create(Long userId, Long termsId) {
+		return create(userId, termsId, LocalDateTime.now());
+	}
+
+	public static UserTermsAgreement create(Long userId, Long termsId, LocalDateTime agreedAt) {
+		return UserTermsAgreement.builder()
+			.userId(userId)
+			.termsId(termsId)
+			.agreedAt(agreedAt)
+			.build();
+	}
+}

--- a/modules/terms/src/main/java/kr/flint/terms/dto/response/TermsRes.java
+++ b/modules/terms/src/main/java/kr/flint/terms/dto/response/TermsRes.java
@@ -1,0 +1,34 @@
+package kr.flint.terms.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.flint.terms.domain.Terms;
+import kr.flint.terms.domain.TermsType;
+
+@Schema(description = "약관 응답")
+public record TermsRes(
+	@Schema(description = "약관 ID", example = "1", type = "string")
+	Long id,
+	@Schema(description = "약관 유형", example = "SERVICE")
+	TermsType type,
+	@Schema(description = "약관 제목", example = "서비스 이용약관")
+	String title,
+	@Schema(description = "약관 본문")
+	String content,
+	@Schema(description = "필수 동의 여부", example = "true")
+	boolean required,
+	@Schema(description = "활성 시각", example = "2026-05-01T00:00:00")
+	LocalDateTime activeAt
+) {
+	public static TermsRes from(Terms terms) {
+		return new TermsRes(
+			terms.getId(),
+			terms.getType(),
+			terms.getTitle(),
+			terms.getContent(),
+			terms.isRequired(),
+			terms.getActiveAt()
+		);
+	}
+}

--- a/modules/terms/src/main/java/kr/flint/terms/exception/TermsErrorCode.java
+++ b/modules/terms/src/main/java/kr/flint/terms/exception/TermsErrorCode.java
@@ -1,0 +1,22 @@
+package kr.flint.terms.exception;
+
+import org.springframework.http.HttpStatus;
+
+import kr.flint.shared.exception.AppError;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermsErrorCode implements AppError {
+	TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "TERMS.NOT_FOUND", "Terms Not Found", "약관을 찾을 수 없습니다."),
+	REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "TERMS.REQUIRED_NOT_AGREED", "Required Terms Not Agreed", "필수 약관에 모두 동의해야 합니다."),
+	INVALID_TERMS_AGREEMENT(HttpStatus.BAD_REQUEST, "TERMS.INVALID_AGREEMENT", "Invalid Terms Agreement", "유효하지 않은 약관 동의입니다."),
+	NO_ACTIVE_REQUIRED_TERMS(HttpStatus.INTERNAL_SERVER_ERROR, "TERMS.NO_ACTIVE_REQUIRED", "No Active Required Terms", "활성 필수 약관이 없습니다."),
+	FORBIDDEN_TERMS_ADMIN(HttpStatus.FORBIDDEN, "TERMS.ADMIN_FORBIDDEN", "Terms Admin Forbidden", "약관 관리 권한이 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String title;
+	private final String detail;
+}

--- a/modules/terms/src/main/java/kr/flint/terms/exception/TermsException.java
+++ b/modules/terms/src/main/java/kr/flint/terms/exception/TermsException.java
@@ -1,0 +1,14 @@
+package kr.flint.terms.exception;
+
+import kr.flint.shared.exception.GeneralException;
+
+public class TermsException extends GeneralException {
+
+	public TermsException(TermsErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public TermsException(TermsErrorCode errorCode, Object... args) {
+		super(errorCode, args);
+	}
+}

--- a/modules/terms/src/main/java/kr/flint/terms/repository/TermsRepository.java
+++ b/modules/terms/src/main/java/kr/flint/terms/repository/TermsRepository.java
@@ -1,0 +1,16 @@
+package kr.flint.terms.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.flint.terms.domain.Terms;
+import kr.flint.terms.domain.TermsType;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+	List<Terms> findByActiveAtLessThanEqual(LocalDateTime activeAt);
+
+	List<Terms> findByTypeAndActiveAtLessThanEqual(TermsType type, LocalDateTime activeAt);
+}

--- a/modules/terms/src/main/java/kr/flint/terms/repository/UserTermsAgreementRepository.java
+++ b/modules/terms/src/main/java/kr/flint/terms/repository/UserTermsAgreementRepository.java
@@ -1,0 +1,8 @@
+package kr.flint.terms.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.flint.terms.domain.UserTermsAgreement;
+
+public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {
+}

--- a/modules/terms/src/main/java/kr/flint/terms/service/TermsService.java
+++ b/modules/terms/src/main/java/kr/flint/terms/service/TermsService.java
@@ -1,0 +1,104 @@
+package kr.flint.terms.service;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import kr.flint.terms.domain.Terms;
+import kr.flint.terms.domain.TermsType;
+import kr.flint.terms.domain.UserTermsAgreement;
+import kr.flint.terms.exception.TermsErrorCode;
+import kr.flint.terms.exception.TermsException;
+import kr.flint.terms.repository.TermsRepository;
+import kr.flint.terms.repository.UserTermsAgreementRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TermsService {
+
+	private final TermsRepository termsRepository;
+	private final UserTermsAgreementRepository userTermsAgreementRepository;
+
+	public List<Terms> getCurrentTerms(@Nullable TermsType type) {
+		LocalDateTime now = LocalDateTime.now();
+		if (type != null) {
+			return selectLatestByType(termsRepository.findByTypeAndActiveAtLessThanEqual(type, now));
+		}
+		return selectLatestByType(termsRepository.findByActiveAtLessThanEqual(now));
+	}
+
+	public Terms getById(Long termsId) {
+		return termsRepository.findById(termsId)
+			.orElseThrow(() -> new TermsException(TermsErrorCode.TERMS_NOT_FOUND));
+	}
+
+	@Transactional
+	public Terms createTermsVersion(TermsType type, String title, String content, boolean required, LocalDateTime activeAt) {
+		return termsRepository.save(Terms.create(type, title, content, required, activeAt));
+	}
+
+	@Transactional
+	public void validateAndCreateAgreements(Long userId, List<Long> agreedTermsIds) {
+		if (CollectionUtils.isEmpty(agreedTermsIds)) {
+			throw new TermsException(TermsErrorCode.REQUIRED_TERMS_NOT_AGREED);
+		}
+
+		List<Terms> currentTerms = getCurrentTerms(null);
+		Set<Long> currentTermsIds = extractTermsIds(currentTerms);
+		Set<Long> requiredTermsIds = currentTerms.stream()
+			.filter(Terms::isRequired)
+			.map(Terms::getId)
+			.collect(java.util.stream.Collectors.toSet());
+
+		if (requiredTermsIds.isEmpty()) {
+			throw new TermsException(TermsErrorCode.NO_ACTIVE_REQUIRED_TERMS);
+		}
+
+		Set<Long> agreedIds = new HashSet<>(agreedTermsIds);
+		if (!currentTermsIds.containsAll(agreedIds)) {
+			throw new TermsException(TermsErrorCode.INVALID_TERMS_AGREEMENT);
+		}
+
+		if (!agreedIds.containsAll(requiredTermsIds)) {
+			throw new TermsException(TermsErrorCode.REQUIRED_TERMS_NOT_AGREED);
+		}
+
+		List<UserTermsAgreement> agreements = currentTerms.stream()
+			.map(Terms::getId)
+			.filter(agreedIds::contains)
+			.map(termsId -> UserTermsAgreement.create(userId, termsId))
+			.toList();
+
+		userTermsAgreementRepository.saveAll(agreements);
+	}
+
+	private Set<Long> extractTermsIds(List<Terms> terms) {
+		return terms.stream()
+			.map(Terms::getId)
+			.collect(java.util.stream.Collectors.toSet());
+	}
+
+	private List<Terms> selectLatestByType(List<Terms> terms) {
+		Map<TermsType, Terms> latestByType = new EnumMap<>(TermsType.class);
+		for (Terms term : terms) {
+			latestByType.merge(term.getType(), term, (current, candidate) ->
+				candidate.isNewerThan(current) ? candidate : current
+			);
+		}
+		return Arrays.stream(TermsType.values())
+			.map(latestByType::get)
+			.filter(java.util.Objects::nonNull)
+			.toList();
+	}
+}

--- a/modules/terms/src/test/java/kr/flint/terms/service/TermsServiceTest.java
+++ b/modules/terms/src/test/java/kr/flint/terms/service/TermsServiceTest.java
@@ -1,0 +1,143 @@
+package kr.flint.terms.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import kr.flint.terms.domain.Terms;
+import kr.flint.terms.domain.TermsType;
+import kr.flint.terms.domain.UserTermsAgreement;
+import kr.flint.terms.exception.TermsErrorCode;
+import kr.flint.terms.exception.TermsException;
+import kr.flint.terms.repository.TermsRepository;
+import kr.flint.terms.repository.UserTermsAgreementRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TermsServiceTest {
+
+	@Mock
+	private TermsRepository termsRepository;
+
+	@Mock
+	private UserTermsAgreementRepository userTermsAgreementRepository;
+
+	@InjectMocks
+	private TermsService termsService;
+
+	@Nested
+	@DisplayName("getCurrentTerms")
+	class GetCurrentTerms {
+
+		@Test
+		@DisplayName("유형별 최신 활성 약관만 반환")
+		void latestActiveTermsByType() {
+			// given
+			Terms oldService = createTerms(1L, TermsType.SERVICE, true, LocalDateTime.now().minusDays(10));
+			Terms newService = createTerms(2L, TermsType.SERVICE, true, LocalDateTime.now().minusDays(1));
+			Terms privacy = createTerms(3L, TermsType.PRIVACY, true, LocalDateTime.now().minusDays(2));
+			when(termsRepository.findByActiveAtLessThanEqual(any(LocalDateTime.class)))
+				.thenReturn(List.of(oldService, privacy, newService));
+
+			// when
+			List<Terms> result = termsService.getCurrentTerms(null);
+
+			// then
+			assertThat(result).extracting(Terms::getId).containsExactly(2L, 3L);
+		}
+	}
+
+	@Nested
+	@DisplayName("validateAndCreateAgreements")
+	class ValidateAndCreateAgreements {
+
+		@Test
+		@DisplayName("필수 약관과 선택 약관 동의를 저장")
+		void success() {
+			// given
+			Terms service = createTerms(1L, TermsType.SERVICE, true, LocalDateTime.now().minusDays(1));
+			Terms privacy = createTerms(2L, TermsType.PRIVACY, true, LocalDateTime.now().minusDays(1));
+			Terms marketing = createTerms(3L, TermsType.MARKETING, false, LocalDateTime.now().minusDays(1));
+			when(termsRepository.findByActiveAtLessThanEqual(any(LocalDateTime.class)))
+				.thenReturn(List.of(service, privacy, marketing));
+
+			// when
+			termsService.validateAndCreateAgreements(100L, List.of(1L, 2L, 3L));
+
+				// then
+				verify(userTermsAgreementRepository).saveAll(argThat(agreements -> {
+					assertThat(agreements).hasSize(3);
+					assertThat(agreements).extracting(UserTermsAgreement::getTermsId)
+						.containsExactly(1L, 2L, 3L);
+					return true;
+				}));
+			}
+
+		@Test
+		@DisplayName("필수 약관 누락 시 예외")
+		void missingRequiredTerms() {
+			// given
+			Terms service = createTerms(1L, TermsType.SERVICE, true, LocalDateTime.now().minusDays(1));
+			Terms privacy = createTerms(2L, TermsType.PRIVACY, true, LocalDateTime.now().minusDays(1));
+			when(termsRepository.findByActiveAtLessThanEqual(any(LocalDateTime.class)))
+				.thenReturn(List.of(service, privacy));
+
+			// when & then
+			assertThatThrownBy(() -> termsService.validateAndCreateAgreements(100L, List.of(1L)))
+				.isInstanceOf(TermsException.class)
+				.extracting("errorCode")
+				.isEqualTo(TermsErrorCode.REQUIRED_TERMS_NOT_AGREED);
+		}
+
+		@Test
+		@DisplayName("현재 활성 약관이 아닌 ID 포함 시 예외")
+		void invalidTermsId() {
+			// given
+			Terms service = createTerms(2L, TermsType.SERVICE, true, LocalDateTime.now().minusDays(1));
+			Terms privacy = createTerms(3L, TermsType.PRIVACY, true, LocalDateTime.now().minusDays(1));
+			when(termsRepository.findByActiveAtLessThanEqual(any(LocalDateTime.class)))
+				.thenReturn(List.of(service, privacy));
+
+			// when & then
+			assertThatThrownBy(() -> termsService.validateAndCreateAgreements(100L, List.of(1L, 2L, 3L)))
+				.isInstanceOf(TermsException.class)
+				.extracting("errorCode")
+				.isEqualTo(TermsErrorCode.INVALID_TERMS_AGREEMENT);
+		}
+
+		@Test
+		@DisplayName("활성 필수 약관이 없으면 예외")
+		void noActiveRequiredTerms() {
+			// given
+			Terms marketing = createTerms(3L, TermsType.MARKETING, false, LocalDateTime.now().minusDays(1));
+			when(termsRepository.findByActiveAtLessThanEqual(any(LocalDateTime.class)))
+				.thenReturn(List.of(marketing));
+
+			// when & then
+			assertThatThrownBy(() -> termsService.validateAndCreateAgreements(100L, List.of(3L)))
+				.isInstanceOf(TermsException.class)
+				.extracting("errorCode")
+				.isEqualTo(TermsErrorCode.NO_ACTIVE_REQUIRED_TERMS);
+		}
+	}
+
+	private Terms createTerms(Long id, TermsType type, boolean required, LocalDateTime activeAt) {
+		Terms terms = Terms.create(type, type.getDescription(), "content", required, activeAt);
+		ReflectionTestUtils.setField(terms, "id", id);
+		return terms;
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'flint-api'
 
 include 'apps:api'
+include 'apps:admin-api'
 
 include 'modules:shared'
 include 'modules:user'
@@ -11,6 +12,7 @@ include 'modules:bookmark'
 include 'modules:taste'
 include 'modules:ott'
 include 'modules:search'
+include 'modules:terms'
 
 include 'infra:redis'
 include 'infra:storage'


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #148

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 약관/정책 관리 기능 추가
  * 사용자가 가입 시 필수 약관 동의가 요구됨
  * 현재 유효한 약관을 조회하는 공개 API 제공
  * 약관 유형별(서비스/개인정보/마케팅) 관리 및 버전 지원

* **테스트**
  * 약관 서비스 및 관리자 기능에 대한 단위/통합 테스트 추가

* **기타(작업)**
  * 빌드/배포 파이프라인에 관리 API 프로젝트 포함 및 아티팩트 생성 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->