### PR TITLE
refactor/#165: batch 가상 스레드로 수정

### DIFF
--- a/apps/admin-api/src/main/resources/application.yml
+++ b/apps/admin-api/src/main/resources/application.yml
@@ -66,5 +66,6 @@ flint:
       export-base-url: https://files.tmdb.org/p/exports
       download-dir: ${java.io.tmpdir}/flint-tmdb-exports
       chunk-size: 100
+      concurrency-limit: 50
       retry-attempts: 3
       retry-back-off-ms: 2000

--- a/apps/batch/src/main/java/kr/flint/batch/config/BatchProperties.java
+++ b/apps/batch/src/main/java/kr/flint/batch/config/BatchProperties.java
@@ -14,6 +14,7 @@ public record BatchProperties(
 		String exportBaseUrl,
 		String downloadDir,
 		Integer chunkSize,
+		Integer concurrencyLimit,
 		Integer retryAttempts,
 		Long retryBackOffMs
 	) {

--- a/apps/batch/src/main/java/kr/flint/batch/config/TmdbBatchAsyncConfig.java
+++ b/apps/batch/src/main/java/kr/flint/batch/config/TmdbBatchAsyncConfig.java
@@ -2,23 +2,41 @@ package kr.flint.batch.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 public class TmdbBatchAsyncConfig {
 
 	public static final String TMDB_TASK_EXECUTOR = "tmdbTaskExecutor";
+	private static final int DEFAULT_CONCURRENCY_LIMIT = 50;
+	private static final long TASK_TERMINATION_TIMEOUT_MS = 60_000;
+
+	private final BatchProperties batchProperties;
+
+	public TmdbBatchAsyncConfig(BatchProperties batchProperties) {
+		this.batchProperties = batchProperties;
+	}
 
 	@Bean(name = TMDB_TASK_EXECUTOR)
 	public TaskExecutor tmdbTaskExecutor() {
-		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(50);
-		executor.setMaxPoolSize(50);
-		executor.setQueueCapacity(100);
-		executor.setThreadNamePrefix("tmdb-batch-");
-		executor.setWaitForTasksToCompleteOnShutdown(true);
-		executor.initialize();
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("tmdb-batch-");
+		executor.setVirtualThreads(true);
+		executor.setConcurrencyLimit(resolveConcurrencyLimit());
+		executor.setRejectTasksWhenLimitReached(false);
+		executor.setTaskTerminationTimeout(TASK_TERMINATION_TIMEOUT_MS);
 		return executor;
+	}
+
+	private int resolveConcurrencyLimit() {
+		if (batchProperties.tmdb() == null || batchProperties.tmdb().concurrencyLimit() == null) {
+			return DEFAULT_CONCURRENCY_LIMIT;
+		}
+
+		int concurrencyLimit = batchProperties.tmdb().concurrencyLimit();
+		if (concurrencyLimit < 1) {
+			throw new IllegalStateException("flint.batch.tmdb.concurrency-limit must be greater than 0");
+		}
+		return concurrencyLimit;
 	}
 }

--- a/apps/batch/src/test/java/kr/flint/batch/repository/ContentBatchJdbcRepositoryTest.java
+++ b/apps/batch/src/test/java/kr/flint/batch/repository/ContentBatchJdbcRepositoryTest.java
@@ -121,10 +121,15 @@ class ContentBatchJdbcRepositoryTest {
 		));
 
 		Map<String, Object> content = jdbcTemplate.queryForMap("""
-			SELECT title, `year`, author, description, poster, bookmark_count, created_at
+			SELECT title, `year`, author, description, poster, bookmark_count
 			FROM content
 			WHERE id = ?
 			""", contentId);
+		Timestamp updatedCreatedAt = jdbcTemplate.queryForObject(
+			"SELECT created_at FROM content WHERE id = ?",
+			Timestamp.class,
+			contentId
+		);
 
 		assertThat(content.get("title")).isEqualTo("Third");
 		assertThat(((Number)content.get("year")).intValue()).isEqualTo(2026);
@@ -132,7 +137,7 @@ class ContentBatchJdbcRepositoryTest {
 		assertThat(content.get("description")).isEqualTo("third");
 		assertThat(content.get("poster")).isEqualTo("third-poster");
 		assertThat(((Number)content.get("bookmark_count")).intValue()).isEqualTo(7);
-		assertThat(content.get("created_at")).isEqualTo(createdAt);
+		assertThat(updatedCreatedAt).isEqualTo(createdAt);
 		assertThat(count("content")).isEqualTo(1);
 		assertThat(count("genre")).isEqualTo(3);
 		assertThat(count("content_genre")).isEqualTo(3);


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #165

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * TMDB 배치 내보내기 작업의 동시성 제한 설정을 추가했습니다. 기본값은 50으로 설정되어 있으며, 필요에 따라 구성을 통해 조정할 수 있습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imflint/FLINT-SERVER/pull/167)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->