### PR TITLE
refactor/#206 북마크 개수 제한 제거

### DIFF
--- a/apps/api/src/main/java/kr/flint/api/domain/content/repository/ContentQueryRepository.java
+++ b/apps/api/src/main/java/kr/flint/api/domain/content/repository/ContentQueryRepository.java
@@ -51,22 +51,28 @@ public class ContentQueryRepository {
 	}
 
 	public List<GetContentDetailRes> getContentDetailList(Long userId){
-		return getBookmarkedContentRows(userId, null, 10).stream()
+		// limit 0 → 북마크한 작품 전체 반환
+		return getBookmarkedContentRows(userId, null, 0).stream()
 			.map(BookmarkedContentRow::toResponse)
 			.toList();
 	}
 
+	// limit <= 0 이면 제한 없이 전체 조회
 	public List<BookmarkedContentRow> getBookmarkedContentRows(Long userId, Long cursor, int limit) {
-		List<Tuple> bookmarkRows = jpaQueryFactory
+		var bookmarkQuery = jpaQueryFactory
 			.select(contentBookmark.id, contentBookmark.contentId)
 			.from(contentBookmark)
 			.where(
 				contentBookmark.userId.eq(userId),
 				cursor != null ? contentBookmark.id.lt(cursor) : null
 			)
-			.orderBy(contentBookmark.id.desc())
-			.limit(limit)
-			.fetch();
+			.orderBy(contentBookmark.id.desc());
+
+		if (limit > 0) {
+			bookmarkQuery.limit(limit);
+		}
+
+		List<Tuple> bookmarkRows = bookmarkQuery.fetch();
 
 		if (bookmarkRows.isEmpty()) return List.of();
 


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 북마크된 콘텐츠 조회 로직을 개선했습니다. 이제 고정된 개수 제한 없이 전체 북마크 목록을 조회할 수 있으며, 필요에 따라 유연한 제한 조건을 적용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->